### PR TITLE
feat: Add Libertadores 2026 groups and update competition dates

### DIFF
--- a/config/css-registry.json
+++ b/config/css-registry.json
@@ -394,7 +394,7 @@
       {
         "path": "public/participante/css/libertadores-lp.css",
         "loadedBy": ["participante/fronts/libertadores.html (inline <link>)"],
-        "description": "Landing Page da Libertadores 2026 — hero, countdown, notícias, timeline de fases. Namespace liberta-*. Usa tokens --app-liberta-*"
+        "description": "Landing Page da Libertadores 2026 — hero, countdown, grupos da fase de grupos (grid 2col), notícias, timeline de fases com estado upcoming. Namespace liberta-*. Usa tokens --app-liberta-*. Keyframes: app-pulse (de _app-tokens.css)"
       },
       {
         "path": "public/participante/css/copa-brasil-lp.css",

--- a/public/participante/css/libertadores-lp.css
+++ b/public/participante/css/libertadores-lp.css
@@ -434,3 +434,100 @@
     vertical-align: middle;
     text-transform: uppercase;
 }
+
+/* ═══════════════════════════════════════════════════
+   STATS STRIP — 4 colunas
+   ═══════════════════════════════════════════════════ */
+.liberta-stats-strip--4col {
+    grid-template-columns: repeat(4, 1fr);
+}
+
+.liberta-stat-item--highlight {
+    border-color: var(--app-liberta-border, rgba(27, 94, 32, 0.35));
+    background: var(--app-liberta-muted, rgba(27, 94, 32, 0.15));
+}
+
+/* ═══════════════════════════════════════════════════
+   GRUPOS — Grid + Cards
+   ═══════════════════════════════════════════════════ */
+.liberta-grupos-chamada {
+    font-family: var(--app-font-base, 'Inter', sans-serif);
+    font-size: 0.75rem;
+    color: var(--app-text-muted, rgba(255, 255, 255, 0.5));
+    margin: -0.5rem 0 1rem;
+    font-style: italic;
+}
+
+.liberta-grupos-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.liberta-grupo-card {
+    background: var(--app-surface, #1a1a1a);
+    border: 1px solid var(--app-border, #333);
+    border-radius: 0.65rem;
+    overflow: hidden;
+}
+
+.liberta-grupo-header {
+    font-family: var(--app-font-brand, 'Russo One', sans-serif);
+    font-size: 0.7rem;
+    color: var(--app-liberta-secondary, #D4AF37);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.5rem 0.6rem 0.25rem;
+    border-bottom: 1px solid var(--app-liberta-border, rgba(27, 94, 32, 0.35));
+    background: var(--app-liberta-muted, rgba(27, 94, 32, 0.15));
+}
+
+.liberta-grupo-times {
+    padding: 0.35rem 0;
+}
+
+.liberta-grupo-time {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.6rem;
+    font-family: var(--app-font-base, 'Inter', sans-serif);
+    font-size: 0.7rem;
+    color: var(--app-text-primary, #fff);
+}
+
+.liberta-grupo-pais {
+    font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
+    font-size: 0.5rem;
+    color: var(--app-text-muted, rgba(255, 255, 255, 0.4));
+    min-width: 1.6rem;
+    text-transform: uppercase;
+}
+
+.liberta-grupo-time--br {
+    color: var(--app-liberta-accent, #2E7D32);
+    font-weight: 600;
+}
+
+.liberta-grupo-time--br .liberta-grupo-pais {
+    color: var(--app-liberta-accent, #2E7D32);
+}
+
+/* ═══════════════════════════════════════════════════
+   TIMELINE — Estado "upcoming" (próxima fase)
+   ═══════════════════════════════════════════════════ */
+.liberta-timeline-item--upcoming::before {
+    background: var(--app-liberta-accent, #2E7D32);
+    box-shadow: 0 0 8px rgba(46, 125, 50, 0.3);
+    animation: app-pulse 2s ease-in-out infinite;
+}
+
+.liberta-timeline-item--upcoming .liberta-timeline-fase {
+    color: var(--app-liberta-accent, #2E7D32);
+}
+
+.liberta-timeline-badge--upcoming {
+    color: var(--app-liberta-accent, #2E7D32);
+    background: rgba(46, 125, 50, 0.12);
+    border: 1px solid rgba(46, 125, 50, 0.25);
+}

--- a/public/participante/fronts/libertadores.html
+++ b/public/participante/fronts/libertadores.html
@@ -42,8 +42,8 @@
             </div>
 
             <p class="liberta-hero-info">
-                <span class="material-icons">event_available</span>
-                Final estimada: Novembro 2026
+                <span class="material-icons">stadium</span>
+                Final: 28 Nov · Estádio Centenário, Montevidéu
             </p>
         </div>
     </section>
@@ -51,7 +51,7 @@
     <!-- ═══════════════════════════════════════════════════
          STATS STRIP — Formato da competição
          ═══════════════════════════════════════════════════ -->
-    <div class="liberta-stats-strip">
+    <div class="liberta-stats-strip liberta-stats-strip--4col">
         <div class="liberta-stat-item">
             <span class="liberta-stat-value">32</span>
             <span class="liberta-stat-label">Clubes</span>
@@ -64,7 +64,26 @@
             <span class="liberta-stat-value">8</span>
             <span class="liberta-stat-label">Grupos</span>
         </div>
+        <div class="liberta-stat-item liberta-stat-item--highlight">
+            <span class="liberta-stat-value">6</span>
+            <span class="liberta-stat-label">Times BR</span>
+        </div>
     </div>
+
+    <!-- ═══════════════════════════════════════════════════
+         GRUPOS — Sorteio 19/Mar/2026
+         ═══════════════════════════════════════════════════ -->
+    <section class="liberta-section">
+        <div class="liberta-section-header">
+            <span class="liberta-section-icon"><span class="material-icons">grid_view</span></span>
+            <h2 class="liberta-section-title">Grupos Definidos</h2>
+            <span class="liberta-section-badge">sorteio 19/mar</span>
+        </div>
+        <p class="liberta-grupos-chamada">Seu time caiu no grupo da morte?</p>
+        <div id="liberta-grupos-grid" class="liberta-grupos-grid">
+            <!-- Preenchido via JS -->
+        </div>
+    </section>
 
     <!-- ═══════════════════════════════════════════════════
          NOTÍCIAS
@@ -97,4 +116,4 @@
     <div class="pb-24"></div>
 </div>
 
-<link rel="stylesheet" href="/participante/css/libertadores-lp.css">
+<link rel="stylesheet" href="/participante/css/libertadores-lp.css?v=2">

--- a/public/participante/js/modules/participante-libertadores.js
+++ b/public/participante/js/modules/participante-libertadores.js
@@ -1,21 +1,75 @@
 // participante-libertadores.js
-// v1.0 - Controller da Landing Page "Libertadores 2026"
+// v2.0 - Controller da Landing Page "Libertadores 2026"
+// v2.0 - Atualizado com grupos definidos (sorteio 19/Mar/2026)
 //
 // Fontes de dados:
 //   - API: /api/noticias/libertadores (Google News RSS, cache 30min)
+//   - Grupos: dados estáticos do sorteio oficial CONMEBOL
 
 let countdownInterval = null;
 
-// Data da Final da Libertadores 2026 (estimada — 3ª semana de novembro)
-const FINAL_DATE = new Date('2026-11-21T21:00:00-03:00');
+// Data da Final da Libertadores 2026 — 28 Nov, Estádio Centenário, Montevidéu
+const FINAL_DATE = new Date('2026-11-28T21:00:00-03:00');
 
-// Fases estáticas da competição
+// Fases da competição (datas confirmadas CONMEBOL)
 const FASES_LIBERTADORES = [
-    { fase: 'Fase de Grupos',       info: 'Fevereiro — Maio 2026',  times: '32 clubes • 8 grupos',  ativa: false },
-    { fase: 'Oitavas de Final',     info: 'Maio — Junho 2026',      times: '16 clubes',              ativa: false },
-    { fase: 'Quartas de Final',     info: 'Julho — Agosto 2026',    times: '8 clubes',               ativa: false },
-    { fase: 'Semifinais',           info: 'Setembro — Outubro 2026',times: '4 clubes',               ativa: false },
-    { fase: 'Grande Final',         info: 'Novembro 2026',          times: 'Jogo único',             final: true  },
+    { fase: 'Fase de Grupos',       info: '7 Abr — 28 Mai 2026',   times: '32 clubes • 8 grupos',  proxima: true },
+    { fase: 'Oitavas de Final',     info: 'Julho 2026',             times: '16 clubes',              ativa: false },
+    { fase: 'Quartas de Final',     info: 'Setembro 2026',          times: '8 clubes',               ativa: false },
+    { fase: 'Semifinais',           info: 'Outubro 2026',           times: '4 clubes',               ativa: false },
+    { fase: 'Grande Final',         info: '28 Nov 2026 · Centenário, Montevidéu', times: 'Jogo único', final: true },
+];
+
+// Grupos definidos — Sorteio 19/Mar/2026 (CONMEBOL, Luque/PAR)
+const GRUPOS_LIBERTADORES = [
+    { grupo: 'A', times: [
+        { nome: 'Flamengo', pais: 'BRA', brasileiro: true },
+        { nome: 'Estudiantes', pais: 'ARG' },
+        { nome: 'Cusco', pais: 'PER' },
+        { nome: 'Ind. Medellín', pais: 'COL' },
+    ]},
+    { grupo: 'B', times: [
+        { nome: 'Nacional', pais: 'URU' },
+        { nome: 'Universitario', pais: 'PER' },
+        { nome: 'Coquimbo Unido', pais: 'CHI' },
+        { nome: 'Tolima', pais: 'COL' },
+    ]},
+    { grupo: 'C', times: [
+        { nome: 'Fluminense', pais: 'BRA', brasileiro: true },
+        { nome: 'Bolívar', pais: 'BOL' },
+        { nome: 'Dep. La Guaira', pais: 'VEN' },
+        { nome: 'Ind. Rivadavia', pais: 'ARG' },
+    ]},
+    { grupo: 'D', times: [
+        { nome: 'Boca Juniors', pais: 'ARG' },
+        { nome: 'Cruzeiro', pais: 'BRA', brasileiro: true },
+        { nome: 'Univ. Católica', pais: 'CHI' },
+        { nome: 'Barcelona', pais: 'ECU' },
+    ]},
+    { grupo: 'E', times: [
+        { nome: 'Peñarol', pais: 'URU' },
+        { nome: 'Corinthians', pais: 'BRA', brasileiro: true },
+        { nome: 'Santa Fe', pais: 'COL' },
+        { nome: 'Platense', pais: 'ARG' },
+    ]},
+    { grupo: 'F', times: [
+        { nome: 'Palmeiras', pais: 'BRA', brasileiro: true },
+        { nome: 'Cerro Porteño', pais: 'PAR' },
+        { nome: 'Junior Barranquilla', pais: 'COL' },
+        { nome: 'Sporting Cristal', pais: 'PER' },
+    ]},
+    { grupo: 'G', times: [
+        { nome: 'LDU', pais: 'ECU' },
+        { nome: 'Lanús', pais: 'ARG' },
+        { nome: 'Always Ready', pais: 'BOL' },
+        { nome: 'Mirassol', pais: 'BRA', brasileiro: true },
+    ]},
+    { grupo: 'H', times: [
+        { nome: 'Ind. del Valle', pais: 'ECU' },
+        { nome: 'Libertad', pais: 'PAR' },
+        { nome: 'Rosario Central', pais: 'ARG' },
+        { nome: 'Univ. Central', pais: 'VEN' },
+    ]},
 ];
 
 // ═══════════════════════════════════════════════════
@@ -32,6 +86,7 @@ export async function inicializarLibertadoresParticipante(params) {
         renderizarCountdown();
         countdownInterval = setInterval(renderizarCountdown, 60000);
 
+        renderizarGrupos();
         renderizarFases();
 
         await carregarNoticias();
@@ -79,6 +134,30 @@ function renderizarCountdown() {
 }
 
 // ═══════════════════════════════════════════════════
+// GRUPOS
+// ═══════════════════════════════════════════════════
+
+function renderizarGrupos() {
+    const container = document.getElementById('liberta-grupos-grid');
+    if (!container) return;
+
+    container.innerHTML = GRUPOS_LIBERTADORES.map(g => {
+        const timesHtml = g.times.map(t => {
+            const cls = t.brasileiro ? 'liberta-grupo-time liberta-grupo-time--br' : 'liberta-grupo-time';
+            return `<div class="${cls}">
+                <span class="liberta-grupo-pais">${t.pais}</span>
+                <span class="liberta-grupo-nome">${t.nome}</span>
+            </div>`;
+        }).join('');
+
+        return `<div class="liberta-grupo-card">
+            <div class="liberta-grupo-header">Grupo ${g.grupo}</div>
+            <div class="liberta-grupo-times">${timesHtml}</div>
+        </div>`;
+    }).join('');
+}
+
+// ═══════════════════════════════════════════════════
 // FASES (TIMELINE)
 // ═══════════════════════════════════════════════════
 
@@ -89,13 +168,16 @@ function renderizarFases() {
     container.innerHTML = FASES_LIBERTADORES.map(f => {
         const isFinal = !!f.final;
         const isAtiva = !!f.ativa;
-        const cls = isFinal
-            ? 'liberta-timeline-item liberta-timeline-item--final'
-            : isAtiva
-            ? 'liberta-timeline-item liberta-timeline-item--active'
-            : 'liberta-timeline-item';
+        const isProxima = !!f.proxima;
 
-        const badge = isAtiva ? '<span class="liberta-timeline-badge">em andamento</span>' : '';
+        let cls = 'liberta-timeline-item';
+        if (isFinal) cls += ' liberta-timeline-item--final';
+        else if (isAtiva) cls += ' liberta-timeline-item--active';
+        else if (isProxima) cls += ' liberta-timeline-item--upcoming';
+
+        let badge = '';
+        if (isAtiva) badge = '<span class="liberta-timeline-badge">em andamento</span>';
+        else if (isProxima) badge = '<span class="liberta-timeline-badge liberta-timeline-badge--upcoming">em breve</span>';
 
         return `
         <div class="${cls}">


### PR DESCRIPTION
## 📋 Resumo da Alteração

Atualização da Landing Page da Libertadores 2026 com os grupos oficiais definidos no sorteio de 19/Mar/2026 (CONMEBOL). Inclui:

- **Grupos definidos**: 8 grupos com 32 clubes (4 por grupo), com destaque para os 6 times brasileiros
- **Datas confirmadas**: Final atualizada para 28 Nov 2026 no Estádio Centenário, Montevidéu
- **Nova seção visual**: Grid de grupos com cards mostrando país e nome de cada time
- **Timeline atualizada**: Fase de Grupos marcada como "próxima" com badge "em breve"
- **Stats strip**: Adicionado destaque para "6 Times BR"

## 🎯 Módulo Afetado

- [x] Outro: Landing Page Libertadores 2026

## 🔧 Arquivos Modificados

- `public/participante/js/modules/participante-libertadores.js` - Adicionado array `GRUPOS_LIBERTADORES` com 8 grupos, função `renderizarGrupos()`, atualização de datas e estados de fase (v1.0 → v2.0)
- `public/participante/css/libertadores-lp.css` - Novos estilos para `.liberta-grupos-grid`, `.liberta-grupo-card`, `.liberta-grupo-time`, estado `--upcoming` na timeline
- `public/participante/fronts/libertadores.html` - Nova seção "Grupos Definidos", atualização de hero info, adição de stat item "6 Times BR", cache-bust CSS
- `config/css-registry.json` - Atualização de descrição do CSS

## ✅ Como Testar

1. Acesse a Landing Page da Libertadores 2026
2. Valide que a seção "Grupos Definidos" renderiza com 8 cards (2 colunas)
3. Confirme que times brasileiros (Flamengo, Fluminense, Cruzeiro, Corinthians, Palmeiras, Mirassol) aparecem em verde/destaque
4. Verifique que a Final mostra "28 Nov · Estádio Centenário, Montevidéu"
5. Confirme que "Fase de Grupos" tem badge "em breve" com animação de pulse

## ✨ Checklist

- [x] Testado localmente
- [x] Sem breaking changes
- [x] Dados estáticos do sorteio oficial CONMEBOL

https://claude.ai/code/session_016EyhphVSeHHKezo4Ag6cvj