### PR TITLE
Fix ligaConfig fallback for zona indicators in extrato

### DIFF
--- a/public/participante/js/modules/participante-extrato-ui.js
+++ b/public/participante/js/modules/participante-extrato-ui.js
@@ -1054,6 +1054,7 @@ export async function renderizarExtratoParticipante(extrato, participanteId) {
     if (extrato.ligaConfig?.zonaConfig) {
         const zonaConfig = extrato.ligaConfig.zonaConfig;
         ligaConfigCache = {
+            liga_id: extrato.ligaId || window.PARTICIPANTE_IDS?.ligaId,
             ranking_rodada: {
                 total_participantes: zonaConfig.totalParticipantes || DEFAULT_TOTAL_PARTICIPANTES,
                 faixas: zonaConfig.faixas || null,
@@ -1064,6 +1065,14 @@ export async function renderizarExtratoParticipante(extrato, participanteId) {
         };
         window.ligaConfigCache = ligaConfigCache;
         if (window.Log) Log.debug("[EXTRATO-UI] ✅ ligaConfigCache populado:", { totalParticipantes: zonaConfig.totalParticipantes });
+    } else {
+        // ✅ v11.4 FIX: Fallback — buscar config da liga via API quando ligaConfig não vem no extrato
+        // Cobre: path de cálculo (fluxoFinanceiroController), caches antigos, e dados do IndexedDB
+        const ligaId = extrato.ligaId || window.PARTICIPANTE_IDS?.ligaId;
+        if (ligaId && (!ligaConfigCache || ligaConfigCache.liga_id !== ligaId)) {
+            await fetchLigaConfigSilent(ligaId);
+            if (window.Log) Log.debug("[EXTRATO-UI] 🔄 ligaConfigCache via fallback API:", { ligaId, populado: !!ligaConfigCache });
+        }
     }
 
     await verificarStatusRenovacao();

--- a/public/participante/js/modules/participante-extrato.js
+++ b/public/participante/js/modules/participante-extrato.js
@@ -597,6 +597,8 @@ async function carregarExtrato(ligaId, timeId) {
                     inscricao: cacheData.inscricao || null,
                     fonte: cacheData.fonte,
                     temporada: temporada,
+                    // ✅ v6.1 FIX: Passar ligaConfig para indicadores de zona (X/✓/○)
+                    ligaConfig: cacheData.ligaConfig || null,
                 };
                 usouCacheBackend = true;
             } else if (!ePreTemporadaReal && (cacheData.fonte === 'inscricao-nova-temporada' ||
@@ -630,6 +632,8 @@ async function carregarExtrato(ligaId, timeId) {
                         extratoTravado: cacheData.extratoTravado || false,
                         rodadaTravada: cacheData.rodadaTravada || null,
                         rodadaDesistencia: cacheData.rodadaDesistencia || null,
+                        // ✅ v6.1 FIX: Passar ligaConfig para indicadores de zona (X/✓/○)
+                        ligaConfig: cacheData.ligaConfig || null,
                     };
                     usouCacheBackend = true;
                     if (window.Log)


### PR DESCRIPTION
## 📋 Resumo da Alteração

Implementa fallback para buscar `ligaConfig` via API quando não vem no extrato, garantindo que indicadores de zona (X/✓/○) sejam renderizados corretamente. Também adiciona `ligaConfig` ao cache backend para evitar perda de dados em fluxos alternativos.

## 🎯 Módulo Afetado

- [x] Outro: Extrato de Participante / Indicadores de Zona

## 🔧 Arquivos Modificados

- `public/participante/js/modules/participante-extrato-ui.js` - Adiciona fallback `fetchLigaConfigSilent()` quando `ligaConfig` não vem no extrato; armazena `liga_id` no cache para validação
- `public/participante/js/modules/participante-extrato.js` - Passa `ligaConfig` do cache backend para o extrato em dois fluxos de carregamento

## ✅ Como Testar

1. Acesse extrato de participante com dados em cache antigo (sem `ligaConfig`)
2. Valide que indicadores de zona (X/✓/○) são renderizados corretamente
3. Verifique console para logs de fallback API (`🔄 ligaConfigCache via fallback API`)

## ✨ Checklist

- [x] Testado localmente
- [x] Multi-tenant validado (usa `ligaId` do extrato ou `window.PARTICIPANTE_IDS`)
- [x] Sem breaking changes (fallback silencioso, não afeta fluxo principal)

https://claude.ai/code/session_01VS7yzZFSUgfCi5WRUmy3nY