### PR TITLE
fix(auth): migra login premium de OIDC ROPC para popup OAuth

### DIFF
--- a/public/participante-login.html
+++ b/public/participante-login.html
@@ -873,15 +873,11 @@
                     <p class="premium-card-sub">Conta Globo — mesmo login do Cartola FC</p>
                 </div>
                 <div class="premium-form">
-                    <input type="email" id="premium-email" class="premium-input"
-                           placeholder="email@gmail.com" autocomplete="email" spellcheck="false">
-                    <input type="password" id="premium-senha" class="premium-input"
-                           placeholder="Senha" autocomplete="current-password">
                     <div id="premium-error" class="premium-error" style="display:none;"></div>
                     <button type="button" id="premium-btn-conectar" class="premium-btn-connect"
                             onclick="premiumFlow.conectar()">
                         <span class="material-symbols-outlined" id="premium-btn-icon">login</span>
-                        <span id="premium-btn-label">Conectar com Globo</span>
+                        <span id="premium-btn-label">Entrar com Globo</span>
                     </button>
                 </div>
                 <button type="button" class="premium-btn-voltar" onclick="premiumFlow.voltar()">
@@ -1264,6 +1260,7 @@
             const OAUTH_DOMAIN = window.location.host;
 
             let popupWindow = null;
+            let isPremiumFlow = false;
 
             function abrirPopupGlobo() {
                 const loading = document.getElementById('loading');
@@ -1348,17 +1345,31 @@
                         credentials: 'include',
                         body: JSON.stringify({
                             glbToken: data.glbToken,
-                            timeId: data.timeId
+                            timeId: data.timeId,
+                            requirePremium: isPremiumFlow
                         })
                     });
 
                     const result = await response.json();
+
+                    // Tratamento especial para NOT_PREMIUM no fluxo premium
+                    if (response.status === 403 && result.code === 'NOT_PREMIUM') {
+                        isPremiumFlow = false;
+                        const premiumFormPanel = document.getElementById('premium-form-panel');
+                        const premiumRejectPanel = document.getElementById('premium-reject-panel');
+                        if (premiumFormPanel) premiumFormPanel.style.display = 'none';
+                        if (premiumRejectPanel) premiumRejectPanel.style.display = 'block';
+                        loading.classList.remove('show');
+                        return;
+                    }
 
                     if (!response.ok || !result.success) {
                         throw new Error(result.error || 'Erro ao criar sessão');
                     }
 
                     console.log('[LOGIN] Sessão criada via popup OAuth:', result);
+
+                    isPremiumFlow = false;
 
                     // Limpar chave do app
                     sessionStorage.removeItem('participante_app_loaded');
@@ -1392,100 +1403,22 @@
                     this._el('premium-form-panel').style.display = 'block';
                     this._el('premium-reject-panel').style.display = 'none';
                     this._el('premium-error').style.display = 'none';
-                    setTimeout(() => this._el('premium-email')?.focus(), 50);
                 },
 
                 voltar() {
+                    isPremiumFlow = false;
                     if (this._loginCard) this._loginCard.style.display = '';
                     if (this._premiumCard) this._premiumCard.style.display = 'none';
-                    const emailEl = this._el('premium-email');
-                    const senhaEl = this._el('premium-senha');
-                    if (emailEl) emailEl.value = '';
-                    if (senhaEl) senhaEl.value = '';
                 },
 
-                async conectar() {
-                    let navigating = false;
-                    const email = this._el('premium-email')?.value.trim();
-                    const senha = this._el('premium-senha')?.value;
-                    const btnEl  = this._el('premium-btn-conectar');
-                    const iconEl = this._el('premium-btn-icon');
-                    const labelEl = this._el('premium-btn-label');
+                conectar() {
                     const errorEl = this._el('premium-error');
-
-                    if (!email || !senha) {
-                        errorEl.textContent = 'Preencha email e senha.';
-                        errorEl.style.display = 'block';
-                        return;
-                    }
-
-                    errorEl.style.display = 'none';
-                    btnEl.disabled = true;
-                    iconEl.textContent = 'sync';
-                    iconEl.style.animation = 'spin 1s linear infinite';
-                    labelEl.textContent = 'Conectando...';
-
-                    try {
-                        const res = await fetch('/api/participante/auth/premium', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            credentials: 'include',
-                            body: JSON.stringify({ email, senha })
-                        });
-                        const data = await res.json();
-
-                        if (data.success) {
-                            navigating = true;
-                            window.location.href = '/participante/';
-                            return;
-                        }
-
-                        if (data.code === 'NOT_PREMIUM') {
-                            this._el('premium-form-panel').style.display = 'none';
-                            this._el('premium-reject-panel').style.display = 'block';
-                            return;
-                        }
-
-                        if (data.code === 'CAPTCHA_REQUIRED') {
-                            errorEl.textContent = 'Autenticação automática bloqueada pela Globo. Use o método Bookmarklet no painel admin.';
-                            errorEl.style.display = 'block';
-                            return;
-                        }
-
-                        // INVALID_CREDENTIALS e outros — mensagem explícita
-                        if (data.code === 'INVALID_CREDENTIALS') {
-                            errorEl.textContent = 'Email ou senha incorretos. Use as mesmas credenciais do Cartola FC.';
-                        } else {
-                            errorEl.textContent = data.message || 'Erro ao autenticar. Tente novamente.';
-                        }
-                        errorEl.style.display = 'block';
-
-                    } catch (_) {
-                        errorEl.textContent = 'Erro de rede. Tente novamente.';
-                        errorEl.style.display = 'block';
-                    } finally {
-                        if (!navigating) {
-                            btnEl.disabled = false;
-                            iconEl.textContent = 'login';
-                            iconEl.style.animation = '';
-                            labelEl.textContent = 'Conectar com Globo';
-                        }
-                    }
+                    if (errorEl) errorEl.style.display = 'none';
+                    isPremiumFlow = true;
+                    abrirPopupGlobo();
                 }
             };
 
-            const _bindPremiumKeys = () => {
-                ['premium-email', 'premium-senha'].forEach(id => {
-                    document.getElementById(id)?.addEventListener('keydown', e => {
-                        if (e.key === 'Enter') premiumFlow.conectar();
-                    });
-                });
-            };
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', _bindPremiumKeys);
-            } else {
-                _bindPremiumKeys();
-            }
         </script>
 
         <!-- 🛡️ PROTEÇÃO CLIENT-SIDE -->

--- a/routes/participante-auth.js
+++ b/routes/participante-auth.js
@@ -890,7 +890,7 @@ router.get("/globo/popup/callback", async (req, res) => {
 router.post("/globo/create-session", async (req, res) => {
     console.log("[PARTICIPANTE-AUTH] Criando sessão via glbToken...");
 
-    const { glbToken, timeId } = req.body;
+    const { glbToken, timeId, requirePremium } = req.body;
 
     if (!glbToken || !timeId) {
         return res.status(400).json({
@@ -949,6 +949,15 @@ router.post("/globo/create-session", async (req, res) => {
         const participanteEncontrado = ligaEncontrada.participantes.find(
             (p) => String(p.time_id) === String(timeIdGlobo)
         );
+
+        // 5a. Verificar flag premium se exigido pelo fluxo
+        if (requirePremium && !participanteEncontrado?.premium) {
+            return res.status(403).json({
+                success: false,
+                code: "NOT_PREMIUM",
+                error: "Conta Globo válida, mas sem acesso Premium neste sistema."
+            });
+        }
 
         // ✅ v2.3: Incluir fallback para nome_cartoleiro
         const dadosReais = {
@@ -1195,78 +1204,14 @@ function gerarHtmlPopupErro(codigo, mensagem) {
 }
 
 // ── EXPORT para testes ──────────────────────────────────────────────
+// Rota legada desativada: o ROPC (Password Grant) da Globo foi revogado.
+// O login premium agora usa o popup OAuth via /globo/create-session?requirePremium=true.
 export async function handlerAuthPremium(req, res) {
-    try {
-        const { email, senha } = req.body;
-        // NUNCA logar senha
-        console.log('[PARTICIPANTE-AUTH] /auth/premium tentativa:', { email });
-
-        if (!email || !senha) {
-            return res.status(400).json({ success: false, code: 'MISSING_FIELDS', message: 'Email e senha são obrigatórios.' });
-        }
-
-        // 1. Autenticar na Globo
-        const authResult = await cartolaProService.autenticar(email, senha);
-        if (!authResult.success) {
-            return res.status(401).json({ success: false, code: 'INVALID_CREDENTIALS', message: 'Email ou senha incorretos.' });
-        }
-        const glbId = authResult.glbId;
-
-        // 2. Obter time_id
-        const timeResult = await cartolaProService.buscarMeuTime(glbId);
-        if (!timeResult.success || !timeResult.time?.timeId) {
-            return res.status(400).json({ success: false, code: 'NO_TIME', message: 'Não foi possível obter seu time da conta Globo.' });
-        }
-        const timeId = timeResult.time.timeId;
-
-        // 3. Buscar liga onde este time existe
-        const liga = await Liga.findOne({ 'participantes.time_id': timeId });
-        if (!liga) {
-            return res.status(404).json({ success: false, code: 'NO_LEAGUE', message: 'Time não encontrado em nenhuma liga.' });
-        }
-
-        // 4. Verificar premium em memória ($ positional operator inválido em filtro MongoDB)
-        const participante = liga.participantes.find(
-            p => String(p.time_id) === String(timeId) && p.premium === true
-        );
-        if (!participante) {
-            return res.status(403).json({ success: false, code: 'NOT_PREMIUM', message: 'Conta Globo válida, mas sem acesso Premium neste sistema.' });
-        }
-
-        // 5. Criar sessão (estrutura idêntica aos outros handlers do arquivo)
-        req.session.participante = {
-            timeId:  String(timeId),
-            ligaId:  liga._id.toString(),
-            premium: true,
-            participante: {
-                nome_cartola: participante.nome_cartola || '',
-                nome_time:    participante.nome_time || '',
-                foto_perfil:  participante.foto_perfil || '',
-                foto_time:    participante.foto_time || '',
-                clube_id:     participante.clube_id || null,
-            },
-        };
-        req.session.cartolaProAuth = {
-            glbid:      glbId,
-            email:      email,
-            expires_at: Math.floor(Date.now() / 1000) + 7200,
-        };
-
-        // Persistir sessão explicitamente (padrão de todos os handlers do arquivo)
-        await new Promise((resolve, reject) => {
-            req.session.save((err) => {
-                if (err) reject(err);
-                else resolve();
-            });
-        });
-
-        console.log('[PARTICIPANTE-AUTH] /auth/premium sucesso:', { email, timeId });
-        return res.json({ success: true });
-
-    } catch (error) {
-        console.error('[PARTICIPANTE-AUTH] /auth/premium erro:', error.message);
-        return res.status(500).json({ success: false, code: 'SERVER_ERROR', message: 'Erro interno. Tente novamente.' });
-    }
+    return res.status(410).json({
+        success: false,
+        code: 'FLOW_DEPRECATED',
+        message: 'Este método de login foi descontinuado. Use o botão "Entrar com Globo" na página de login.'
+    });
 }
 
 // Rota


### PR DESCRIPTION
O endpoint OIDC da Globo revogou o Password Grant (ROPC) para o client_id cartola-web@apps.globoid, causando 401 em toda tentativa de login premium via email/senha.

Mudanças:
- handlerAuthPremium: substituído por stub 410 Gone (ROPC morto)
- /globo/create-session: aceita requirePremium no body; retorna 403 NOT_PREMIUM se participante não tem premium=true na liga
- Login premium: form email/senha removido; botão agora dispara o popup OAuth já funcional (abrirPopupGlobo) com flag isPremiumFlow
- processarTokenExchange: envia requirePremium:true quando fluxo premium; trata resposta 403 NOT_PREMIUM exibindo painel de rejeição

## 📋 Resumo da Alteração

[Descreva o que foi implementado]

## 🎯 Módulo Afetado

- [ ] Mata-Mata
- [ ] Pontos Corridos
- [ ] Fluxo Financeiro
- [ ] Outro: _______

## 🔧 Arquivos Modificados

- `[arquivo]` - [mudança]

## ✅ Como Testar

1. Acesse: [URL]
2. Faça: [ação]
3. Valide: [resultado]

## ✨ Checklist

- [ ] Testado localmente
- [ ] Multi-tenant validado
- [ ] Sem breaking changes
