### PR TITLE
fix(home): corrigir sumiço do Live Ranking Card na home

### DIFF
--- a/public/participante/js/modules/participante-home.js
+++ b/public/participante/js/modules/participante-home.js
@@ -140,7 +140,7 @@ export async function inicializarHomeParticipante(params) {
             const state = MS.currentState;
             const STATES = MS.STATES;
             if (window.Log) Log.info("PARTICIPANTE-HOME", `Matchday state changed: ${state}`);
-            if ((state === STATES.LIVE || state === STATES.LOADING) && !_liveCardActive) {
+            if ((state === STATES.LIVE || state === STATES.LOADING || state === STATES.WAITING) && !_liveCardActive) {
                 ativarLiveRankingCard();
             }
         };
@@ -160,6 +160,12 @@ export function destruirHomeParticipante() {
         window.MatchdayService.off('matchday:state', _matchdayStateHandler);
         _matchdayStateHandler = null;
     }
+    // ✅ v1.4.3: Reset live card — sem isso _liveCardActive fica true e o card
+    // nunca reativa na próxima navegação Home→X→Home
+    _liveCardUnsubscribers.forEach(fn => fn());
+    _liveCardUnsubscribers = [];
+    _prevLiveRanking = null;
+    _liveCardActive = false;
 }
 window.destruirHomeParticipante = destruirHomeParticipante;
 


### PR DESCRIPTION
- Reset _liveCardActive em destruirHomeParticipante: ao navegar Home→X→Home, o flag ficava true e ativarLiveRankingCard() retornava imediatamente sem renderizar o card na volta
- Adicionar estado WAITING no handler matchday:state: mercado fechado com jogos não iniciados transitava LOADING→WAITING sem ativar o card

## 📋 Resumo da Alteração

[Descreva o que foi implementado]

## 🎯 Módulo Afetado

- [ ] Mata-Mata
- [ ] Pontos Corridos
- [ ] Fluxo Financeiro
- [ ] Outro: _______

## 🔧 Arquivos Modificados

- `[arquivo]` - [mudança]

## ✅ Como Testar

1. Acesse: [URL]
2. Faça: [ação]
3. Valide: [resultado]

## ✨ Checklist

- [ ] Testado localmente
- [ ] Multi-tenant validado
- [ ] Sem breaking changes
