### PR TITLE
fix(financeiro): corrigir divergência de saldo Home vs Financeiro

### DIFF
--- a/public/participante/js/modules/participante-extrato.js
+++ b/public/participante/js/modules/participante-extrato.js
@@ -833,6 +833,13 @@ async function carregarExtrato(ligaId, timeId) {
             }
         }
 
+        // ✅ FIX SALDO-CONSISTÊNCIA: Invalidar cache de extrato no CacheV2
+        // Garante que ao voltar para a Home, o saldo exibido seja o mesmo valor fresco
+        // que acabamos de receber do servidor (evita divergência Home vs Financeiro)
+        if (extratoData && window.Cache?.invalidatePrefix) {
+            window.Cache.invalidatePrefix('extrato:');
+        }
+
         // Renderizar se necessário
         // ✅ v5.2: Não renderizar se timeout já disparou (evita sobrescrever tela de timeout)
         if (deveReRenderizar && !timeoutFired) {

--- a/public/participante/js/modules/participante-home.js
+++ b/public/participante/js/modules/participante-home.js
@@ -330,9 +330,11 @@ async function carregarDadosERenderizar(ligaId, timeId, participante) {
             }
         };
 
-        extratoFresh = cacheV2
-            ? await cacheV2.get(`extrato:${ligaId}:${timeId}:${temporadaExtrato}`, fetchExtrato)
-            : await fetchExtrato();
+        // ✅ FIX SALDO-CONSISTÊNCIA: Sempre buscar extrato fresco do servidor
+        // CacheV2 SWR (TTL 1h) servia dados stale quando acertos financeiros eram
+        // registrados, causando divergência entre saldo na Home vs tela Financeiro.
+        // Dados financeiros são críticos e devem sempre vir frescos.
+        extratoFresh = await fetchExtrato();
 
         if (cache && extratoFresh) {
             cache.setExtrato(ligaId, timeId, extratoFresh);
@@ -652,7 +654,9 @@ function processarDadosParaRender(liga, ranking, rodadas, extratoData, meuTimeId
     // Fallback para cálculo manual apenas se não houver dados do extrato
     const saldoConsolidado = extratoData?.resumo?.saldo ?? extratoData?.saldo_atual ?? extratoData?.resumo?.saldo_final ?? null;
 
-    // Cálculo manual apenas como último fallback (não inclui acertos/ajustes)
+    // ⚠️ FALLBACK DE EMERGÊNCIA: calcula saldo apenas por rodadas
+    // EXCLUI: acertos financeiros, taxa de inscrição, ajustes dinâmicos, saldo anterior
+    // Pode divergir significativamente do saldo real — usar somente quando extratoData indisponível
     const saldoCalculadoPorRodadas = minhasRodadas.reduce((total, rodada) => {
         return total + (parseFloat(rodada.valorFinanceiro || rodada.ganho_rodada || 0));
     }, 0);


### PR DESCRIPTION
## Summary

- **Bypass CacheV2 para extrato na Home** — dados financeiros agora sempre vêm frescos do servidor
- **Invalidar CacheV2 extrato ao abrir tela Financeiro** — limpa stale data para consistência ao voltar para Home
- **Documentar fallback saldoCalculadoPorRodadas** — explicitar que exclui acertos/inscrição/ajustes

## Problema

O saldo financeiro exibido na tela **Início** (badge ALERTA) divergia do valor na tela **Financeiro** (hero card).

Exemplo na liga Super Cartola, participante Paulinett:
- Home: **-304,27**
- Financeiro: **-141,27**
- Diferença: **163,00** (= acertos financeiros não refletidos na Home)

## Causa Raiz

O CacheV2 (Stale-While-Revalidate, TTL 1h) envolvia o fetch do extrato na Home:
```javascript
// ANTES (BUG):
extratoFresh = cacheV2
    ? await cacheV2.get(`extrato:...`, fetchExtrato)
    : await fetchExtrato();
```

Quando um acerto era registrado, o CacheV2 continuava servindo o saldo antigo por até 1 hora. A tela Financeiro não usava CacheV2 (fetch direto), então sempre mostrava o valor correto.

## Test plan

- [ ] Navegar para Home → verificar saldo no badge ALERTA
- [ ] Clicar no badge → verificar saldo no hero card do Financeiro → valores idênticos
- [ ] Registrar novo acerto no admin → verificar que Home atualiza na próxima visualização
- [ ] Verificar que Home carrega rapidamente (impacto: ~50-100ms por 1 fetch adicional)
- [ ] Verificar que CacheV2 continua funcionando para ranking/rodadas

https://claude.ai/code/session_013bfnu6HQkMumq1mDtFABgt