### PR TITLE
fix(resta-um): auditoria financeira — idempotência, cache invalidation e recovery

### DIFF
--- a/controllers/restaUmController.js
+++ b/controllers/restaUmController.js
@@ -577,6 +577,7 @@ export async function editarEdicao(req, res) {
         }
 
         // Recalcular taxa se premiação ou fluxo mudaram
+        let avisoTaxaRetroativa = false;
         if (premiacao !== undefined || fluxoFinanceiroHabilitado !== undefined) {
             const p = edicao.premiacao;
             const numGanhadores = 2 + (p.terceiroHabilitado ? 1 : 0);
@@ -585,6 +586,12 @@ export async function editarEdicao(req, res) {
                 + (p.terceiroHabilitado ? p.terceiro : 0);
             const payers = (edicao.participantes || []).length - numGanhadores;
             edicao.taxaEliminacao = payers > 0 ? Math.trunc(pool / payers * 100) / 100 : 0;
+
+            // Aviso: débitos já lançados em rodadas anteriores usam o valor antigo
+            if (!isPendente && (edicao.debitosLancados || []).length > 0 && premiacao !== undefined) {
+                avisoTaxaRetroativa = true;
+                logger.warn(`[RESTA-UM] Liga ${ligaId} — premiação alterada com ${edicao.debitosLancados.length} rodada(s) já processada(s). Débitos anteriores NÃO são recalculados.`);
+            }
         }
 
         edicao.ultima_atualizacao = new Date();
@@ -596,6 +603,9 @@ export async function editarEdicao(req, res) {
             success: true,
             edicao: edicaoNum,
             status: edicao.status,
+            ...(avisoTaxaRetroativa && {
+                aviso: 'Premiação alterada com eliminações já processadas. Débitos das rodadas anteriores não são recalculados retroativamente — apenas novas eliminações usarão a taxa atualizada.',
+            }),
         });
 
     } catch (error) {

--- a/docs/modules-registry.json
+++ b/docs/modules-registry.json
@@ -96,6 +96,24 @@
     "complexity": "high",
     "audits": ["financial", "ui", "security", "business", "performance"]
   },
+  "resta-um": {
+    "name": "Resta Um",
+    "category": "competition",
+    "description": "Eliminação progressiva rodada a rodada — sobreviva ou seja eliminado",
+    "hasFinancial": true,
+    "hasUI": true,
+    "hasAPI": true,
+    "complexity": "high",
+    "colorVar": "--module-resta-um-primary",
+    "status": "active",
+    "files": {
+      "controller": "controllers/restaUmController.js",
+      "manager": "services/orchestrator/managers/RestaUmManager.js",
+      "model": "models/RestaUmCache.js",
+      "frontend": "public/participante/js/modules/participante-resta-um.js"
+    },
+    "audits": ["financial", "ui", "security", "business", "performance"]
+  },
   "campinho": {
     "name": "Campinho",
     "category": "game",

--- a/models/AjusteFinanceiro.js
+++ b/models/AjusteFinanceiro.js
@@ -71,6 +71,20 @@ const AjusteFinanceiroSchema = new mongoose.Schema({
     },
 
     // =========================================================================
+    // IDEMPOTÊNCIA E RASTREABILIDADE
+    // =========================================================================
+    chaveIdempotencia: {
+        type: String,
+        default: null,
+        index: true,
+        sparse: true,
+    },
+    metadata: {
+        type: mongoose.Schema.Types.Mixed,
+        default: null,
+    },
+
+    // =========================================================================
     // CONTROLE
     // =========================================================================
     ativo: {
@@ -186,7 +200,9 @@ AjusteFinanceiroSchema.statics.criar = async function(dados) {
         temporada: Number(dados.temporada || CURRENT_SEASON),
         descricao: dados.descricao,
         valor: Number(dados.valor),
-        criado_por: dados.criado_por || ''
+        criado_por: dados.criado_por || '',
+        ...(dados.chaveIdempotencia && { chaveIdempotencia: dados.chaveIdempotencia }),
+        ...(dados.metadata && { metadata: dados.metadata }),
     });
 
     return ajuste.save();

--- a/models/RestaUmCache.js
+++ b/models/RestaUmCache.js
@@ -83,6 +83,11 @@ const RestaUmCacheSchema = new mongoose.Schema({
     fluxoFinanceiroHabilitado: { type: Boolean, default: false },
     taxaEliminacao: { type: Number, default: 0 }, // pré-calculado na criação
 
+    // Controle de recovery: rodadas que já tiveram débitos financeiros lançados.
+    // Se rodadaAtual >= X mas X não está aqui, os débitos de X podem ter sido perdidos
+    // por crash entre o save() do guard e o lançamento dos AjusteFinanceiro.
+    debitosLancados: { type: [Number], default: [] },
+
     ultima_atualizacao: { type: Date, default: Date.now },
 }, {
     timestamps: true,

--- a/services/orchestrator/managers/RestaUmManager.js
+++ b/services/orchestrator/managers/RestaUmManager.js
@@ -13,6 +13,7 @@ import BaseManager from './BaseManager.js';
 import RestaUmCache from '../../../models/RestaUmCache.js';
 import Rodada from '../../../models/Rodada.js';
 import AjusteFinanceiro from '../../../models/AjusteFinanceiro.js';
+import { invalidarExtratoCache } from '../../../utils/cache-invalidator.js';
 import { CURRENT_SEASON } from '../../../config/seasons.js';
 
 export default class RestaUmManager extends BaseManager {
@@ -27,6 +28,36 @@ export default class RestaUmManager extends BaseManager {
             temColeta: false,
             temFinanceiro: true,
         });
+    }
+
+    /**
+     * Tenta recuperar débitos financeiros não lançados por falha entre o save()
+     * do guard de idempotência e o lançamento dos AjusteFinanceiro.
+     * Seguro de chamar múltiplas vezes — _lancarDebitoEliminacao é idempotente.
+     *
+     * @returns {boolean} true se havia débitos pendentes e foram lançados
+     */
+    async _recoveryFinanceiro(edicao, rodada) {
+        const debitosLancados = edicao.debitosLancados || [];
+        if (debitosLancados.includes(rodada)) return false;
+        if (!edicao.fluxoFinanceiroHabilitado || !edicao.taxaEliminacao) return false;
+
+        const eliminadosNaRodada = edicao.participantes.filter(p => p.rodadaEliminacao === rodada);
+        if (eliminadosNaRodada.length === 0) return false;
+
+        console.log(`[RESTA-UM] R${rodada} recovery financeiro — ${eliminadosNaRodada.length} débito(s) pendente(s)`);
+        for (const el of eliminadosNaRodada) {
+            await this._lancarDebitoEliminacao(
+                edicao.liga_id, edicao.temporada,
+                el.timeId, el.nomeTime,
+                edicao.taxaEliminacao, edicao.edicao, rodada,
+            ).catch(err => console.error('[RESTA-UM-FIN] Erro no débito recovery:', err.message));
+        }
+
+        edicao.debitosLancados = [...debitosLancados, rodada];
+        edicao.markModified('debitosLancados');
+        await edicao.save();
+        return true;
     }
 
     /**
@@ -170,6 +201,10 @@ export default class RestaUmManager extends BaseManager {
                     edicao.taxaEliminacao, edicao.edicao, rodada,
                 ).catch(err => console.error('[RESTA-UM-FIN] Erro no débito:', err.message));
             }
+            // Marcar rodada como financeiramente processada (recovery de janela de falha)
+            edicao.debitosLancados = [...(edicao.debitosLancados || []), rodada];
+            edicao.markModified('debitosLancados');
+            await edicao.save();
         }
 
         // Fluxo financeiro: créditos para premiados quando finalizar
@@ -293,6 +328,7 @@ export default class RestaUmManager extends BaseManager {
                 if (pendente) {
                     // Idempotência primária: rodadaAtual já cobre esta rodada
                     if (pendente.rodadaAtual >= rodada) {
+                        await this._recoveryFinanceiro(pendente, rodada);
                         console.log(`[RESTA-UM] R${rodada} já processada (rodadaAtual=${pendente.rodadaAtual}, pendente) para liga ${ligaId} — ignorando`);
                         return { consolidado: true, ignorado: true, motivo: 'rodada_ja_processada' };
                     }
@@ -330,6 +366,7 @@ export default class RestaUmManager extends BaseManager {
 
             // Idempotência primária: rodadaAtual já cobre esta rodada
             if (edicao.rodadaAtual >= rodada) {
+                await this._recoveryFinanceiro(edicao, rodada);
                 console.log(`[RESTA-UM] R${rodada} já processada (rodadaAtual=${edicao.rodadaAtual}) para liga ${ligaId} — ignorando`);
                 return { consolidado: true, ignorado: true, motivo: 'rodada_ja_processada' };
             }
@@ -352,16 +389,16 @@ export default class RestaUmManager extends BaseManager {
 
     /**
      * Cria débito idempotente para participante eliminado.
-     * Usa descricao única como chave de idempotência.
+     * Usa chaveIdempotencia dedicada (não descricao) como chave de proteção.
      */
     async _lancarDebitoEliminacao(ligaId, temporada, timeId, nomeTime, taxaEliminacao, edicaoNum, rodada) {
-        const descricao = `Resta Um E${edicaoNum} - Eliminado R${rodada}`;
+        const chaveIdempotencia = `resta_um-debito-e${edicaoNum}-r${rodada}-t${timeId}`;
+
         const jaExiste = await AjusteFinanceiro.findOne({
             liga_id: String(ligaId),
             time_id: Number(timeId),
             temporada: Number(temporada),
-            descricao,
-            ativo: true,
+            chaveIdempotencia,
         }).lean();
 
         if (jaExiste) {
@@ -373,10 +410,14 @@ export default class RestaUmManager extends BaseManager {
             liga_id: String(ligaId),
             time_id: timeId,
             temporada,
-            descricao,
+            descricao: `Resta Um E${edicaoNum} - Eliminado R${rodada}`,
             valor: -Math.abs(taxaEliminacao), // débito = negativo
             criado_por: 'RestaUmManager',
+            chaveIdempotencia,
+            metadata: { modulo: 'resta_um', edicao: edicaoNum, rodada },
         });
+
+        await invalidarExtratoCache(String(ligaId), timeId, temporada, 'RestaUm débito eliminação');
         console.log(`[RESTA-UM-FIN] Débito criado: ${nomeTime} -R$${taxaEliminacao} (R${rodada})`);
     }
 
@@ -408,13 +449,12 @@ export default class RestaUmManager extends BaseManager {
         for (const { p, valor, label } of premiados) {
             if (!valor || valor <= 0) continue;
 
-            const descricao = `Resta Um E${edicao.edicao} - ${label}`;
+            const chaveIdempotencia = `resta_um-${label.toLowerCase().replace(/\s+/g, '_')}-e${edicao.edicao}-t${p.timeId}`;
             const jaExiste = await AjusteFinanceiro.findOne({
                 liga_id: String(ligaId),
                 time_id: Number(p.timeId),
                 temporada: Number(temporada),
-                descricao,
-                ativo: true,
+                chaveIdempotencia,
             }).lean();
 
             if (jaExiste) {
@@ -426,10 +466,14 @@ export default class RestaUmManager extends BaseManager {
                 liga_id: String(ligaId),
                 time_id: p.timeId,
                 temporada,
-                descricao,
+                descricao: `Resta Um E${edicao.edicao} - ${label}`,
                 valor: Math.abs(valor), // crédito = positivo
                 criado_por: 'RestaUmManager',
+                chaveIdempotencia,
+                metadata: { modulo: 'resta_um', edicao: edicao.edicao, posicao: label },
             });
+
+            await invalidarExtratoCache(String(ligaId), p.timeId, temporada, `RestaUm crédito ${label}`);
             console.log(`[RESTA-UM-FIN] Crédito criado: ${p.nomeTime} +R$${valor} (${label})`);
         }
     }


### PR DESCRIPTION
## Summary

- **chaveIdempotencia dedicada** no `AjusteFinanceiro` — migração de `descricao` como chave implícita para campo formal com sparse index
- **Invalidação de extratofinanceirocaches** após cada débito/crédito lançado pelo Resta Um (participante vê saldo atualizado imediatamente)
- **Recovery de janela de falha** — novo campo `debitosLancados[]` em `RestaUmCache` detecta rodadas onde o guard foi salvo mas os débitos não foram lançados (crash entre save e AjusteFinanceiro); `onConsolidate` relança automaticamente na próxima chamada
- **metadata** adicionado aos `AjusteFinanceiro` do Resta Um para rastreabilidade Follow the Money
- **Aviso de taxa retroativa** em `editarEdicao` quando premiação muda com rodadas já processadas
- **modules-registry.json** — `resta-um` registrado no catálogo oficial de módulos

## Test plan

- [ ] Eliminar participante com `fluxoFinanceiroHabilitado = true` → verificar débito criado com `chaveIdempotencia` e `metadata` corretos
- [ ] Verificar que `extratofinanceirocaches` do eliminado é deletado após o débito
- [ ] Simular re-chamada de `onConsolidate` para mesma rodada → recovery detecta `debitosLancados` e não duplica débitos
- [ ] Editar premiação com edição em andamento → verificar campo `aviso` na resposta
- [ ] Verificar entrada `resta-um` em `/auditor-module resta-um`

🤖 Generated with [Claude Code](https://claude.com/claude-code)