### PR TITLE
Add initialization sync and background refresh for Brasileirão data

### DIFF
--- a/jobs/sync-brasileirao.js
+++ b/jobs/sync-brasileirao.js
@@ -161,6 +161,25 @@ function iniciar() {
 
     // Verificar a cada hora
     jobTimer = setInterval(verificarEExecutar, CONFIG.INTERVALO_VERIFICACAO * 60 * 1000);
+
+    // Sync de inicialização: se dados ausentes ou > 24h, sincronizar imediatamente
+    CalendarioBrasileirao.findOne(
+        { temporada: CONFIG.TEMPORADA_PADRAO },
+        { ultima_atualizacao: 1 }
+    ).lean().then(cal => {
+        if (!cal || !cal.ultima_atualizacao) {
+            console.log('[SYNC-BRASILEIRAO] Sem dados para temporada ' + CONFIG.TEMPORADA_PADRAO + ' — sync de inicialização...');
+            executarSync();
+        } else {
+            const horas = (Date.now() - new Date(cal.ultima_atualizacao).getTime()) / 3600000;
+            if (horas > 24) {
+                console.log(`[SYNC-BRASILEIRAO] Dados com ${Math.floor(horas)}h — sync de inicialização...`);
+                executarSync();
+            }
+        }
+    }).catch(err => {
+        console.warn('[SYNC-BRASILEIRAO] Erro ao verificar dados na inicialização:', err.message);
+    });
 }
 
 /**

--- a/public/participante/css/brasileirao-tabela.css
+++ b/public/participante/css/brasileirao-tabela.css
@@ -1017,12 +1017,14 @@
     border-top: none;
     border-bottom-left-radius: 14px;
     border-bottom-right-radius: 14px;
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
     max-height: 800px;
     transition: max-height 0.35s ease;
 }
 
 .agenda-content.collapsed {
     max-height: 0;
+    overflow: hidden;
     border-width: 0;
 }

--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -83,7 +83,7 @@
         <link rel="stylesheet" href="css/noticias-time.css?v=20260323" />
 
         <!-- ✅ Tabela do Brasileirão -->
-        <link rel="stylesheet" href="css/brasileirao-tabela.css?v=20260323" />
+        <link rel="stylesheet" href="css/brasileirao-tabela.css?v=20260324" />
 
         <!-- ✅ TurnoGroup: colapsável por turno (componente reutilizável) -->
         <link rel="stylesheet" href="css/components/turno-group.css?v=20260322" />

--- a/services/brasileirao-tabela-service.js
+++ b/services/brasileirao-tabela-service.js
@@ -449,6 +449,16 @@ async function obterResumoParaExibicao(temporada) {
         };
     }
 
+    // Background sync se dados estão > 2h — não bloqueia a resposta
+    if (calendario.ultima_atualizacao) {
+        const horasDesde = (Date.now() - new Date(calendario.ultima_atualizacao).getTime()) / 3600000;
+        if (horasDesde > 2) {
+            sincronizarTabela(temporada, false).catch(e =>
+                console.warn('[BRASILEIRAO-SERVICE] Background sync falhou:', e.message)
+            );
+        }
+    }
+
     let rodadaAtual = calendario.obterRodadaAtual();
     const rodadaCartola = await obterRodadaCartola();
     if (rodadaCartola) rodadaAtual = rodadaCartola;


### PR DESCRIPTION
## 📋 Resumo da Alteração

Implementação de sincronização inteligente de dados do Brasileirão com duas estratégias:

1. **Sync de inicialização**: Ao iniciar o job, verifica se há dados ausentes ou desatualizados (> 24h) e sincroniza imediatamente
2. **Background sync**: Durante requisições de exibição da tabela, se dados estão > 2h desatualizados, dispara sincronização em background sem bloquear a resposta
3. **Correção de scroll**: Ajusta overflow da agenda para permitir scroll vertical quando conteúdo excede altura máxima

## 🎯 Módulo Afetado

- [x] Pontos Corridos

## 🔧 Arquivos Modificados

- `jobs/sync-brasileirao.js` - Adicionado sync de inicialização ao iniciar o job
- `services/brasileirao-tabela-service.js` - Adicionado background sync ao obter resumo para exibição
- `public/participante/css/brasileirao-tabela.css` - Corrigido overflow para permitir scroll vertical na agenda
- `public/participante/index.html` - Atualizado cache-busting da CSS

## ✅ Como Testar

1. Reinicie o serviço de sync do Brasileirão
2. Verifique logs para confirmar sync de inicialização (se dados ausentes ou > 24h)
3. Acesse a página de tabela do Brasileirão
4. Valide que a agenda permite scroll quando conteúdo excede 800px
5. Aguarde > 2h sem sincronização e acesse novamente para confirmar background sync nos logs

## ✨ Checklist

- [x] Testado localmente
- [x] Multi-tenant validado (usa CONFIG.TEMPORADA_PADRAO)
- [x] Sem breaking changes (sync em background não bloqueia fluxo)

https://claude.ai/code/session_01HJVYP2hhqMcT4MBwZbtP5x