### PR TITLE
feat: Add Copa do Nordeste 2026 landing page with groups and timeline

### DIFF
--- a/public/participante/css/_app-tokens.css
+++ b/public/participante/css/_app-tokens.css
@@ -110,6 +110,15 @@
     --app-copabr-gradient: linear-gradient(135deg, #003087 0%, #001a52 50%, #D4AF37 100%);
     --app-copabr-gradient-subtle: linear-gradient(135deg, rgba(0, 48, 135, 0.2) 0%, rgba(0, 26, 82, 0.15) 100%);
 
+    /* Copa do Nordeste 2026 */
+    --app-copane-primary: #E65100;               /* Laranja Sol do Nordeste */
+    --app-copane-secondary: #D4AF37;             /* Dourado troféu */
+    --app-copane-accent: #2D6A4F;                /* Verde sertão */
+    --app-copane-muted: rgba(230, 81, 0, 0.15);
+    --app-copane-border: rgba(230, 81, 0, 0.35);
+    --app-copane-gradient: linear-gradient(135deg, #E65100 0%, #BF360C 50%, #D4AF37 100%);
+    --app-copane-gradient-subtle: linear-gradient(135deg, rgba(230, 81, 0, 0.2) 0%, rgba(191, 54, 12, 0.15) 100%);
+
     /* Agenda do Dia (Jogos) */
     --app-agenda-primary: #1a6b35;              /* Verde gramado */
     --app-agenda-secondary: #0d3d1e;            /* Verde escuro */

--- a/public/participante/css/copa-nordeste-lp.css
+++ b/public/participante/css/copa-nordeste-lp.css
@@ -1,16 +1,16 @@
 /**
- * Copa do Brasil - Landing Page Styles
+ * Copa do Nordeste - Landing Page Styles
  * =============================================
- * LP dedicada à Copa do Brasil
- * Usa tokens de _app-tokens.css (--app-copabr-*)
- * Mobile-first, dark theme, namespace: copabr-*
+ * LP dedicada à Copa do Nordeste
+ * Usa tokens de _app-tokens.css (--app-copane-*)
+ * Mobile-first, dark theme, namespace: copane-*
  * Dependência: _app-tokens.css
  */
 
 /* ═══════════════════════════════════════════════════
    PAGE CONTAINER
    ═══════════════════════════════════════════════════ */
-.copabr-page {
+.copane-page {
     min-height: 100vh;
     background: var(--app-bg, #0a0a0a);
     padding-bottom: 5rem;
@@ -19,7 +19,7 @@
 /* ═══════════════════════════════════════════════════
    BOTÃO VOLTAR
    ═══════════════════════════════════════════════════ */
-.copabr-btn-voltar {
+.copane-btn-voltar {
     position: sticky;
     top: 12px;
     left: 12px;
@@ -39,56 +39,60 @@
     margin: 12px 0 -48px 12px;
     transition: background 0.2s, transform 0.15s;
 }
-.copabr-btn-voltar:active {
+.copane-btn-voltar:active {
     transform: scale(0.92);
     background: rgba(0, 0, 0, 0.65);
 }
-.copabr-btn-voltar .material-icons {
+.copane-btn-voltar .material-icons {
     font-size: 1.1rem;
 }
 
 /* ═══════════════════════════════════════════════════
    HERO
    ═══════════════════════════════════════════════════ */
-.copabr-hero {
+.copane-hero {
     position: relative;
     overflow: hidden;
     margin: 1rem;
     border-radius: 0.75rem;
-    border: 1px solid var(--app-copabr-border, rgba(0, 48, 135, 0.35));
+    border: 1px solid var(--app-copane-border, rgba(230, 81, 0, 0.35));
     background: var(--app-surface, #1a1a1a);
 }
 
-/* Faixa tricolor — Azul → Vermelho → Dourado */
-.copabr-flag-accent {
+/* Faixa tricolor — Verde → Laranja → Dourado */
+.copane-flag-accent {
     height: 4px;
     background: linear-gradient(
         90deg,
-        var(--app-copabr-primary, #003087) 0%,
-        var(--app-copabr-accent, #C41230) 50%,
-        var(--app-copabr-secondary, #D4AF37) 100%
+        var(--app-copane-accent, #2D6A4F) 0%,
+        var(--app-copane-primary, #E65100) 50%,
+        var(--app-copane-secondary, #D4AF37) 100%
     );
 }
 
-.copabr-hero-content {
+.copane-hero-content {
     position: relative;
     z-index: 1;
     padding: 1.5rem 1rem 1.75rem;
     text-align: center;
 }
 
-/* Escudo/troféu */
-.copabr-hero-emblem {
-    font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Twemoji Mozilla", sans-serif;
+/* Troféu */
+.copane-hero-emblem {
     font-size: 2.5rem;
     line-height: 1;
     margin-bottom: 1rem;
-    filter: drop-shadow(0 2px 8px rgba(212, 175, 55, 0.4));
+    filter: drop-shadow(0 2px 8px rgba(230, 81, 0, 0.4));
 }
 
-.copabr-hero-title {
+.copane-hero-emblem .material-icons {
+    font-size: 2.5rem;
+    color: var(--app-copane-secondary, #D4AF37);
+}
+
+.copane-hero-title {
     font-family: var(--app-font-brand, 'Russo One', sans-serif);
-    font-size: 2rem;
+    font-size: 1.8rem;
     color: var(--app-text-primary, #fff);
     letter-spacing: -0.02em;
     margin: 0;
@@ -96,16 +100,16 @@
     text-transform: uppercase;
 }
 
-.copabr-hero-subtitle {
+.copane-hero-subtitle {
     font-family: var(--app-font-brand, 'Russo One', sans-serif);
     font-size: 2.5rem;
-    color: var(--app-copabr-secondary, #D4AF37);
+    color: var(--app-copane-primary, #E65100);
     margin: 0;
     line-height: 1;
     font-style: italic;
 }
 
-.copabr-hero-local {
+.copane-hero-local {
     font-family: var(--app-font-base, 'Inter', sans-serif);
     font-size: 0.6rem;
     color: var(--app-text-muted, rgba(255, 255, 255, 0.5));
@@ -115,8 +119,8 @@
     font-weight: 500;
 }
 
-/* Chips de status — fase atual, próximo evento */
-.copabr-hero-chips {
+/* Chips de status */
+.copane-hero-chips {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
@@ -124,7 +128,7 @@
     padding: 0 0.25rem;
 }
 
-.copabr-chip {
+.copane-chip {
     display: flex;
     align-items: center;
     gap: 0.4rem;
@@ -136,43 +140,43 @@
     border: 1px solid transparent;
 }
 
-.copabr-chip .material-icons {
+.copane-chip .material-icons {
     font-size: 0.9rem;
     flex-shrink: 0;
 }
 
-.copabr-chip--done {
+.copane-chip--done {
     background: rgba(34, 197, 94, 0.08);
     border-color: rgba(34, 197, 94, 0.25);
     color: #86efac;
 }
-.copabr-chip--done .material-icons { color: #4ade80; }
+.copane-chip--done .material-icons { color: #4ade80; }
 
-.copabr-chip--next {
-    background: rgba(99, 153, 255, 0.1);
-    border-color: rgba(99, 153, 255, 0.3);
-    color: #93c5fd;
+.copane-chip--next {
+    background: rgba(230, 81, 0, 0.1);
+    border-color: rgba(230, 81, 0, 0.3);
+    color: #ffab91;
 }
-.copabr-chip--next .material-icons { color: #6699ff; }
+.copane-chip--next .material-icons { color: var(--app-copane-primary, #E65100); }
 
-.copabr-chip--event {
-    background: var(--app-copabr-muted, rgba(0, 48, 135, 0.15));
-    border-color: var(--app-copabr-border, rgba(0, 48, 135, 0.35));
-    color: var(--app-copabr-secondary, #D4AF37);
+.copane-chip--event {
+    background: var(--app-copane-muted, rgba(230, 81, 0, 0.15));
+    border-color: var(--app-copane-border, rgba(230, 81, 0, 0.35));
+    color: var(--app-copane-secondary, #D4AF37);
 }
-.copabr-chip--event .material-icons { color: var(--app-copabr-secondary, #D4AF37); }
+.copane-chip--event .material-icons { color: var(--app-copane-secondary, #D4AF37); }
 
 /* ═══════════════════════════════════════════════════
-   STATS STRIP — Formato da competição
+   STATS STRIP
    ═══════════════════════════════════════════════════ */
-.copabr-stats-strip {
+.copane-stats-strip {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 0.5rem;
     margin: 0 1rem 1.25rem;
 }
 
-.copabr-stat-item {
+.copane-stat-item {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -182,14 +186,14 @@
     padding: 0.75rem 0.4rem;
 }
 
-.copabr-stat-value {
+.copane-stat-value {
     font-family: var(--app-font-brand, 'Russo One', sans-serif);
     font-size: 1.25rem;
-    color: var(--app-copabr-secondary, #D4AF37);
+    color: var(--app-copane-primary, #E65100);
     line-height: 1;
 }
 
-.copabr-stat-label {
+.copane-stat-label {
     font-family: var(--app-font-base, 'Inter', sans-serif);
     font-size: 0.52rem;
     color: var(--app-text-muted, rgba(255, 255, 255, 0.45));
@@ -203,11 +207,11 @@
 /* ═══════════════════════════════════════════════════
    SECTIONS GENÉRICO
    ═══════════════════════════════════════════════════ */
-.copabr-section {
+.copane-section {
     padding: 1.5rem 1rem 0;
 }
 
-.copabr-section + .copabr-section::before {
+.copane-section + .copane-section::before {
     content: '';
     display: block;
     height: 1px;
@@ -216,19 +220,19 @@
     opacity: 0.5;
 }
 
-.copabr-section-header {
+.copane-section-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 1rem;
 }
 
-.copabr-section-icon .material-icons {
-    color: var(--app-copabr-secondary, #D4AF37);
+.copane-section-icon .material-icons {
+    color: var(--app-copane-primary, #E65100);
     font-size: 1.25rem;
 }
 
-.copabr-section-title {
+.copane-section-title {
     font-family: var(--app-font-brand, 'Russo One', sans-serif);
     font-size: 1rem;
     color: var(--app-text-primary, #fff);
@@ -238,19 +242,19 @@
     font-style: italic;
 }
 
-.copabr-section-badge {
+.copane-section-badge {
     font-family: var(--app-font-base, 'Inter', sans-serif);
     font-size: 0.6rem;
     font-weight: 600;
-    color: var(--app-copabr-secondary, #D4AF37);
-    background: var(--app-copabr-muted, rgba(0, 48, 135, 0.15));
-    border: 1px solid var(--app-copabr-border, rgba(0, 48, 135, 0.35));
+    color: var(--app-copane-primary, #E65100);
+    background: var(--app-copane-muted, rgba(230, 81, 0, 0.15));
+    border: 1px solid var(--app-copane-border, rgba(230, 81, 0, 0.35));
     border-radius: 999px;
     padding: 0.15rem 0.5rem;
     white-space: nowrap;
 }
 
-.copabr-loading-placeholder {
+.copane-loading-placeholder {
     text-align: center;
     color: var(--app-text-muted, rgba(255, 255, 255, 0.4));
     font-size: 0.85rem;
@@ -258,61 +262,67 @@
 }
 
 /* ═══════════════════════════════════════════════════
-   CONFRONTOS 5ª FASE — Grid de jogos
+   GRUPOS — Grid 2x2
    ═══════════════════════════════════════════════════ */
-.copabr-confrontos-info {
-    font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
-    font-size: 0.6rem;
-    color: var(--app-text-muted, rgba(255, 255, 255, 0.5));
-    text-transform: uppercase;
-    margin: 0 0 0.75rem;
-}
-
-.copabr-confrontos-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
-
-.copabr-confronto-card {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.copane-grupos-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 0.5rem;
+}
+
+.copane-grupo-card {
     background: var(--app-surface, #1a1a1a);
     border: 1px solid var(--app-border, #333);
-    border-radius: 0.5rem;
-    padding: 0.55rem 0.75rem;
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+    overflow: hidden;
 }
 
-.copabr-confronto-time {
-    font-family: var(--app-font-base, 'Inter', sans-serif);
-    font-size: 0.72rem;
-    font-weight: 600;
-    color: var(--app-text-primary, #fff);
-    flex: 1;
-    text-align: center;
+.copane-grupo-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--app-copane-border, rgba(230, 81, 0, 0.35));
 }
 
-.copabr-confronto-vs {
-    font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
-    font-size: 0.55rem;
-    font-weight: 700;
-    color: var(--app-copabr-secondary, #D4AF37);
+.copane-grupo-label {
+    font-family: var(--app-font-brand, 'Russo One', sans-serif);
+    font-size: 0.7rem;
+    color: var(--app-copane-primary, #E65100);
     text-transform: uppercase;
-    flex-shrink: 0;
+}
+
+.copane-grupo-times {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.copane-grupo-time {
+    font-family: var(--app-font-base, 'Inter', sans-serif);
+    font-size: 0.65rem;
+    color: var(--app-text-primary, #fff);
+    line-height: 1.4;
+    padding: 0.15rem 0;
+}
+
+.copane-grupo-time--destaque {
+    color: var(--app-copane-primary, #E65100);
+    font-weight: 600;
 }
 
 /* ═══════════════════════════════════════════════════
    NOTÍCIAS — Cards lista
    ═══════════════════════════════════════════════════ */
-.copabr-noticias-lista {
+.copane-noticias-lista {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
 }
 
-.copabr-noticia-card {
+.copane-noticia-card {
     display: flex;
     align-items: flex-start;
     gap: 0.75rem;
@@ -326,32 +336,32 @@
     -webkit-tap-highlight-color: transparent;
 }
 
-.copabr-noticia-card:active {
-    border-color: var(--app-copabr-secondary, #D4AF37);
+.copane-noticia-card:active {
+    border-color: var(--app-copane-primary, #E65100);
 }
 
-.copabr-noticia-icon {
+.copane-noticia-icon {
     width: 2rem;
     height: 2rem;
     flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--app-copabr-muted, rgba(0, 48, 135, 0.15));
+    background: var(--app-copane-muted, rgba(230, 81, 0, 0.15));
     border-radius: 0.5rem;
 }
 
-.copabr-noticia-icon .material-icons {
+.copane-noticia-icon .material-icons {
     font-size: 1rem;
-    color: var(--app-copabr-primary, #003087);
+    color: var(--app-copane-primary, #E65100);
 }
 
-.copabr-noticia-text {
+.copane-noticia-text {
     flex: 1;
     min-width: 0;
 }
 
-.copabr-noticia-title {
+.copane-noticia-title {
     font-family: var(--app-font-base, 'Inter', sans-serif);
     font-size: 0.82rem;
     font-weight: 600;
@@ -364,24 +374,24 @@
     overflow: hidden;
 }
 
-.copabr-noticia-meta {
+.copane-noticia-meta {
     display: flex;
     align-items: center;
     gap: 0.4rem;
     font-size: 0.6rem;
 }
 
-.copabr-noticia-fonte {
-    color: var(--app-copabr-secondary, #D4AF37);
+.copane-noticia-fonte {
+    color: var(--app-copane-primary, #E65100);
     font-weight: 700;
     text-transform: uppercase;
 }
 
-.copabr-noticia-tempo {
+.copane-noticia-tempo {
     color: var(--app-text-muted, rgba(255, 255, 255, 0.4));
 }
 
-.copabr-noticia-chevron {
+.copane-noticia-chevron {
     font-size: 1.1rem;
     color: var(--app-text-muted, rgba(255, 255, 255, 0.3));
     flex-shrink: 0;
@@ -391,31 +401,31 @@
 /* ═══════════════════════════════════════════════════
    FASES — Timeline vertical
    ═══════════════════════════════════════════════════ */
-.copabr-timeline {
+.copane-timeline {
     position: relative;
     padding-left: 1.5rem;
 }
 
-.copabr-timeline::before {
+.copane-timeline::before {
     content: '';
     position: absolute;
     left: 0.25rem;
     top: 0.5rem;
     bottom: 0.5rem;
     width: 2px;
-    background: var(--app-copabr-border, rgba(0, 48, 135, 0.35));
+    background: var(--app-copane-border, rgba(230, 81, 0, 0.35));
 }
 
-.copabr-timeline-item {
+.copane-timeline-item {
     position: relative;
     padding: 0 0 1.5rem 1.25rem;
 }
 
-.copabr-timeline-item:last-child {
+.copane-timeline-item:last-child {
     padding-bottom: 0;
 }
 
-.copabr-timeline-item::before {
+.copane-timeline-item::before {
     content: '';
     position: absolute;
     left: -1.2rem;
@@ -427,64 +437,64 @@
     border: 2px solid var(--app-bg, #0a0a0a);
 }
 
-.copabr-timeline-item--final::before {
-    background: var(--app-copabr-secondary, #D4AF37);
+.copane-timeline-item--final::before {
+    background: var(--app-copane-secondary, #D4AF37);
     box-shadow: 0 0 10px rgba(212, 175, 55, 0.5);
     width: 0.75rem;
     height: 0.75rem;
     left: -1.25rem;
 }
 
-.copabr-timeline-item--active::before {
-    background: #6699ff;
-    box-shadow: 0 0 8px rgba(102, 153, 255, 0.5);
+.copane-timeline-item--active::before {
+    background: var(--app-copane-primary, #E65100);
+    box-shadow: 0 0 8px rgba(230, 81, 0, 0.5);
 }
 
-.copabr-timeline-item--done::before {
+.copane-timeline-item--done::before {
     background: #4ade80;
     opacity: 0.6;
 }
 
-.copabr-timeline-fase {
+.copane-timeline-fase {
     font-family: var(--app-font-brand, 'Russo One', sans-serif);
     font-size: 0.85rem;
     color: var(--app-text-primary, #fff);
     margin-bottom: 0.15rem;
 }
 
-.copabr-timeline-item--final .copabr-timeline-fase {
-    color: var(--app-copabr-secondary, #D4AF37);
+.copane-timeline-item--final .copane-timeline-fase {
+    color: var(--app-copane-secondary, #D4AF37);
     font-style: italic;
 }
 
-.copabr-timeline-item--active .copabr-timeline-fase {
-    color: #6699ff;
+.copane-timeline-item--active .copane-timeline-fase {
+    color: var(--app-copane-primary, #E65100);
 }
 
-.copabr-timeline-item--done .copabr-timeline-fase {
+.copane-timeline-item--done .copane-timeline-fase {
     color: var(--app-text-muted, rgba(255, 255, 255, 0.45));
 }
 
-.copabr-timeline-item--done .copabr-timeline-info {
+.copane-timeline-item--done .copane-timeline-info {
     opacity: 0.6;
 }
 
-.copabr-timeline-info {
+.copane-timeline-info {
     font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
     font-size: 0.6rem;
     color: var(--app-text-muted, rgba(255, 255, 255, 0.5));
     text-transform: uppercase;
 }
 
-.copabr-timeline-badge {
+.copane-timeline-badge {
     display: inline-flex;
     align-items: center;
     font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
     font-size: 0.5rem;
     font-weight: 700;
-    color: #6699ff;
-    background: rgba(102, 153, 255, 0.12);
-    border: 1px solid rgba(102, 153, 255, 0.35);
+    color: var(--app-copane-primary, #E65100);
+    background: rgba(230, 81, 0, 0.12);
+    border: 1px solid rgba(230, 81, 0, 0.35);
     border-radius: 999px;
     padding: 0.1rem 0.4rem;
     margin-left: 0.4rem;
@@ -492,7 +502,7 @@
     text-transform: uppercase;
 }
 
-.copabr-timeline-badge--done {
+.copane-timeline-badge--done {
     color: #4ade80;
     background: rgba(74, 222, 128, 0.1);
     border-color: rgba(74, 222, 128, 0.25);

--- a/public/participante/fronts/copa-brasil.html
+++ b/public/participante/fronts/copa-brasil.html
@@ -53,6 +53,21 @@
     </div>
 
     <!-- ═══════════════════════════════════════════════════
+         CONFRONTOS 5ª FASE — Sorteio 23/03/2026
+         ═══════════════════════════════════════════════════ -->
+    <section class="copabr-section">
+        <div class="copabr-section-header">
+            <span class="copabr-section-icon"><span class="material-icons">sports_soccer</span></span>
+            <h2 class="copabr-section-title">5ª Fase — Confrontos</h2>
+            <span class="copabr-section-badge">16 jogos</span>
+        </div>
+        <p class="copabr-confrontos-info">Ida: 22 Abr &bull; Volta: 13 Mai &bull; Ida e volta</p>
+        <div id="copabr-confrontos-5fase" class="copabr-confrontos-grid">
+            <!-- Preenchido via JS -->
+        </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════
          NOTÍCIAS
          ═══════════════════════════════════════════════════ -->
     <section class="copabr-section">
@@ -83,4 +98,4 @@
     <div class="pb-24"></div>
 </div>
 
-<link rel="stylesheet" href="/participante/css/copa-brasil-lp.css?v=3">
+<link rel="stylesheet" href="/participante/css/copa-brasil-lp.css?v=4">

--- a/public/participante/fronts/copa-nordeste.html
+++ b/public/participante/fronts/copa-nordeste.html
@@ -1,0 +1,100 @@
+<!-- COPA DO NORDESTE - Landing Page / Hub -->
+<!-- Fragmento HTML para inserção via navegação SPA -->
+<div id="copa-nordeste-container" class="copane-page">
+
+    <!-- Botão Voltar -->
+    <button
+        onclick="window.quickAccessBar ? window.quickAccessBar.abrirMenu() : history.back()"
+        class="copane-btn-voltar"
+        aria-label="Voltar">
+        <span class="material-icons">arrow_back</span>
+    </button>
+
+    <!-- ═══════════════════════════════════════════════════
+         HERO / COUNTDOWN
+         ═══════════════════════════════════════════════════ -->
+    <section class="copane-hero">
+        <!-- Faixa tricolor Verde → Laranja → Dourado -->
+        <div class="copane-flag-accent"></div>
+
+        <div class="copane-hero-content">
+            <!-- Troféu -->
+            <div class="copane-hero-emblem"><span class="material-icons">emoji_events</span></div>
+
+            <h1 class="copane-hero-title">Copa do Nordeste</h1>
+            <p class="copane-hero-subtitle">2026</p>
+            <p class="copane-hero-local">Competição Regional — Liga do Nordeste / CBF</p>
+
+            <!-- Chips de status dinâmicos — preenchidos via JS -->
+            <div id="copane-status-chips" class="copane-hero-chips"></div>
+        </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════
+         STATS STRIP — Formato da competição
+         ═══════════════════════════════════════════════════ -->
+    <div class="copane-stats-strip">
+        <div class="copane-stat-item">
+            <span class="copane-stat-value">20</span>
+            <span class="copane-stat-label">Clubes</span>
+        </div>
+        <div class="copane-stat-item">
+            <span class="copane-stat-value">4</span>
+            <span class="copane-stat-label">Grupos</span>
+        </div>
+        <div class="copane-stat-item">
+            <span class="copane-stat-value">23ª</span>
+            <span class="copane-stat-label">Edição</span>
+        </div>
+        <div class="copane-stat-item">
+            <span class="copane-stat-value">7 Jun</span>
+            <span class="copane-stat-label">Final</span>
+        </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════
+         GRUPOS
+         ═══════════════════════════════════════════════════ -->
+    <section class="copane-section">
+        <div class="copane-section-header">
+            <span class="copane-section-icon"><span class="material-icons">groups</span></span>
+            <h2 class="copane-section-title">Grupos</h2>
+            <span class="copane-section-badge">4 grupos</span>
+        </div>
+        <div id="copane-grupos" class="copane-grupos-grid">
+            <!-- Preenchido via JS -->
+        </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════
+         NOTÍCIAS
+         ═══════════════════════════════════════════════════ -->
+    <section class="copane-section">
+        <div class="copane-section-header">
+            <span class="copane-section-icon"><span class="material-icons">newspaper</span></span>
+            <h2 class="copane-section-title">Notícias</h2>
+        </div>
+        <div id="copane-noticias-lista" class="copane-noticias-lista">
+            <div class="copane-loading-placeholder">Carregando notícias...</div>
+        </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════
+         FASES DA COMPETIÇÃO — Timeline
+         ═══════════════════════════════════════════════════ -->
+    <section class="copane-section">
+        <div class="copane-section-header">
+            <span class="copane-section-icon"><span class="material-icons">military_tech</span></span>
+            <h2 class="copane-section-title">Fases da Competição</h2>
+            <span class="copane-section-badge">4 fases</span>
+        </div>
+        <div id="copane-timeline" class="copane-timeline">
+            <!-- Preenchido via JS -->
+        </div>
+    </section>
+
+    <!-- Bottom padding para bottom nav -->
+    <div class="pb-24"></div>
+</div>
+
+<link rel="stylesheet" href="/participante/css/copa-nordeste-lp.css?v=1">

--- a/public/participante/js/modules/participante-copa-brasil.js
+++ b/public/participante/js/modules/participante-copa-brasil.js
@@ -1,13 +1,36 @@
 // participante-copa-brasil.js
-// v1.0 - Controller da Landing Page "Copa do Brasil 2026"
+// v1.1 - Controller da Landing Page "Copa do Brasil 2026"
+// v1.1: Atualiza 5ª Fase com confrontos do sorteio (23/03/2026)
 //
 // Fontes de dados:
 //   - API: /api/noticias/copa-brasil (Google News RSS, cache 30min)
 
 
+// Confrontos da 5ª Fase — Sorteio realizado em 23/03/2026 na CBF
+// Formato: { mandanteIda: 'Time A', visitanteIda: 'Time B' }
+// O mandante da ida joga em casa primeiro; volta no campo do outro
+const CONFRONTOS_5A_FASE = [
+    { mandanteIda: 'Ceará',          visitanteIda: 'Atlético-MG' },
+    { mandanteIda: 'Goiás',          visitanteIda: 'Cruzeiro' },
+    { mandanteIda: 'Atlético-GO',    visitanteIda: 'Athletico-PR' },
+    { mandanteIda: 'Vitória',        visitanteIda: 'Flamengo' },
+    { mandanteIda: 'Confiança',      visitanteIda: 'Grêmio' },
+    { mandanteIda: 'Paysandu',       visitanteIda: 'Vasco' },
+    { mandanteIda: 'CRB',            visitanteIda: 'Fortaleza' },
+    { mandanteIda: 'Remo',           visitanteIda: 'Bahia' },
+    { mandanteIda: 'Chapecoense',    visitanteIda: 'Botafogo' },
+    { mandanteIda: 'Mirassol',       visitanteIda: 'RB Bragantino' },
+    { mandanteIda: 'Barra-SC',       visitanteIda: 'Corinthians' },
+    { mandanteIda: 'Operário-PR',    visitanteIda: 'Fluminense' },
+    { mandanteIda: 'Jacuipense',     visitanteIda: 'Palmeiras' },
+    { mandanteIda: 'Athletic-MG',    visitanteIda: 'Internacional' },
+    { mandanteIda: 'Coritiba',       visitanteIda: 'Santos' },
+    { mandanteIda: 'Juventude',      visitanteIda: 'São Paulo' },
+];
+
+
 // Eventos futuros da Copa do Brasil 2026 — countdown dinâmico para o próximo
 const EVENTOS_COPA_BRASIL = [
-    { label: 'Sorteio da 5ª Fase',    data: new Date('2026-03-23T14:00:00-03:00') },
     { label: '5ª Fase — Ida',         data: new Date('2026-04-22T00:00:00-03:00') },
     { label: '5ª Fase — Volta',       data: new Date('2026-05-13T00:00:00-03:00') },
     { label: 'Oitavas de Final — Ida',data: new Date('2026-08-02T00:00:00-03:00') },
@@ -50,6 +73,7 @@ export async function inicializarCopaBrasilParticipante(params) {
 
     try {
         renderizarInfoHero();
+        renderizarConfrontos5aFase();
         renderizarFases();
         await carregarNoticias();
 
@@ -98,6 +122,23 @@ function renderizarInfoHero() {
     }
 
     container.innerHTML = html;
+}
+
+// ═══════════════════════════════════════════════════
+// CONFRONTOS 5ª FASE — Sorteio 23/03/2026
+// ═══════════════════════════════════════════════════
+
+function renderizarConfrontos5aFase() {
+    const container = document.getElementById('copabr-confrontos-5fase');
+    if (!container) return;
+
+    container.innerHTML = CONFRONTOS_5A_FASE.map(c => `
+        <div class="copabr-confronto-card">
+            <span class="copabr-confronto-time">${c.mandanteIda}</span>
+            <span class="copabr-confronto-vs">vs</span>
+            <span class="copabr-confronto-time">${c.visitanteIda}</span>
+        </div>`
+    ).join('');
 }
 
 // ═══════════════════════════════════════════════════

--- a/public/participante/js/modules/participante-copa-nordeste.js
+++ b/public/participante/js/modules/participante-copa-nordeste.js
@@ -1,0 +1,268 @@
+// participante-copa-nordeste.js
+// v1.0 - Controller da Landing Page "Copa do Nordeste 2026"
+//
+// Fontes de dados:
+//   - API: /api/noticias/copa-nordeste (Google News RSS, cache 1h)
+
+
+// Grupos da Copa do Nordeste 2026 — 20 times, 4 grupos de 5
+const GRUPOS_COPA_NORDESTE = {
+    A: {
+        label: 'Grupo A',
+        times: [
+            { nome: 'Vitória',        destaque: true },
+            { nome: 'ASA' },
+            { nome: 'Sousa' },
+            { nome: 'Itabaiana' },
+            { nome: 'Fluminense-PI' },
+        ]
+    },
+    B: {
+        label: 'Grupo B',
+        times: [
+            { nome: 'Juazeirense' },
+            { nome: 'CRB',            destaque: true },
+            { nome: 'Botafogo-PB' },
+            { nome: 'Confiança' },
+            { nome: 'Piauí' },
+        ]
+    },
+    C: {
+        label: 'Grupo C',
+        times: [
+            { nome: 'Ceará',          destaque: true },
+            { nome: 'Sport',          destaque: true },
+            { nome: 'América-RN' },
+            { nome: 'Imperatriz' },
+            { nome: 'Ferroviário' },
+        ]
+    },
+    D: {
+        label: 'Grupo D',
+        times: [
+            { nome: 'Fortaleza',      destaque: true },
+            { nome: 'Retrô' },
+            { nome: 'ABC' },
+            { nome: 'Maranhão' },
+            { nome: 'Jacuipense' },
+        ]
+    }
+};
+
+// Eventos futuros da Copa do Nordeste 2026 — countdown dinâmico
+const EVENTOS_COPA_NORDESTE = [
+    { label: 'Início da Fase de Grupos',  data: new Date('2026-03-25T00:00:00-03:00') },
+    { label: 'Fim da Fase de Grupos',     data: new Date('2026-05-04T00:00:00-03:00') },
+    { label: 'Quartas de Final',          data: new Date('2026-05-11T00:00:00-03:00') },
+    { label: 'Semifinais — Ida',          data: new Date('2026-05-18T00:00:00-03:00') },
+    { label: 'Semifinais — Volta',        data: new Date('2026-05-25T00:00:00-03:00') },
+    { label: 'Grande Final — Ida',        data: new Date('2026-05-31T00:00:00-03:00') },
+    { label: 'Grande Final — Volta',      data: new Date('2026-06-07T00:00:00-03:00') },
+];
+
+// Retorna o próximo evento que ainda não ocorreu
+function proximoEvento() {
+    const agora = new Date();
+    return EVENTOS_COPA_NORDESTE.find(e => e.data > agora) || EVENTOS_COPA_NORDESTE[EVENTOS_COPA_NORDESTE.length - 1];
+}
+
+// Fases da competição — 4 fases
+const FASES_COPA_NORDESTE = [
+    { fase: 'Fase de Grupos',    info: '25 Mar — 4 Mai 2026',  times: '20 clubes — 4 grupos de 5',        proxima: true },
+    { fase: 'Quartas de Final',  info: '11 Mai 2026',          times: '8 clubes — jogo único'                             },
+    { fase: 'Semifinais',        info: '18 + 25 Mai 2026',     times: '4 clubes — ida/volta'                              },
+    { fase: 'Grande Final',      info: '31 Mai + 7 Jun 2026',  times: 'Ida e volta',                      final: true     },
+];
+
+// ═══════════════════════════════════════════════════
+// INICIALIZAÇÃO
+// ═══════════════════════════════════════════════════
+
+export async function inicializarCopaNordesteParticipante(params) {
+    if (window.Log) Log.info('COPA-NORDESTE', 'Inicializando LP Copa do Nordeste 2026...');
+
+    // Registrar cleanup no window para o navigation poder chamar ao sair
+    window.destruirCopaNordesteParticipante = destruirCopaNordesteParticipante;
+
+    try {
+        renderizarInfoHero();
+        renderizarGrupos();
+        renderizarFases();
+        await carregarNoticias();
+
+        if (window.Log) Log.info('COPA-NORDESTE', 'LP renderizada com sucesso');
+    } catch (erro) {
+        console.error('[COPA-NORDESTE] Erro na inicialização:', erro);
+    }
+}
+
+export function destruirCopaNordesteParticipante() {
+    // noop — sem intervalos ativos
+}
+
+// ═══════════════════════════════════════════════════
+// INFO HERO — Status dinâmico da competição
+// ═══════════════════════════════════════════════════
+
+function renderizarInfoHero() {
+    const container = document.getElementById('copane-status-chips');
+    if (!container) return;
+
+    const faseAtual = [...FASES_COPA_NORDESTE].reverse().find(f => f.concluida);
+    const fasePendente = FASES_COPA_NORDESTE.find(f => f.proxima);
+    const evento = proximoEvento();
+
+    let html = '';
+
+    if (faseAtual) {
+        html += `<div class="copane-chip copane-chip--done">
+            <span class="material-icons">check_circle</span>
+            ${faseAtual.fase} concluída
+        </div>`;
+    }
+    if (fasePendente) {
+        html += `<div class="copane-chip copane-chip--next">
+            <span class="material-icons">hourglass_top</span>
+            Próxima: ${fasePendente.fase}
+        </div>`;
+    }
+    if (evento) {
+        const dataStr = evento.data.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+        html += `<div class="copane-chip copane-chip--event">
+            <span class="material-icons">event</span>
+            ${evento.label} — ${dataStr}
+        </div>`;
+    }
+
+    container.innerHTML = html;
+}
+
+// ═══════════════════════════════════════════════════
+// GRUPOS — Grid 2x2
+// ═══════════════════════════════════════════════════
+
+function renderizarGrupos() {
+    const container = document.getElementById('copane-grupos');
+    if (!container) return;
+
+    container.innerHTML = Object.values(GRUPOS_COPA_NORDESTE).map(grupo => {
+        const timesHtml = grupo.times.map(t => {
+            const cls = t.destaque ? 'copane-grupo-time copane-grupo-time--destaque' : 'copane-grupo-time';
+            return `<div class="${cls}">${t.nome}</div>`;
+        }).join('');
+
+        return `
+        <div class="copane-grupo-card">
+            <div class="copane-grupo-header">
+                <span class="copane-grupo-label">${grupo.label}</span>
+            </div>
+            <div class="copane-grupo-times">${timesHtml}</div>
+        </div>`;
+    }).join('');
+}
+
+// ═══════════════════════════════════════════════════
+// FASES (TIMELINE)
+// ═══════════════════════════════════════════════════
+
+function renderizarFases() {
+    const container = document.getElementById('copane-timeline');
+    if (!container) return;
+
+    container.innerHTML = FASES_COPA_NORDESTE.map(f => {
+        const isFinal    = !!f.final;
+        const isConcluida = !!f.concluida;
+        const isProxima  = !!f.proxima;
+
+        const cls = isFinal
+            ? 'copane-timeline-item copane-timeline-item--final'
+            : isProxima
+            ? 'copane-timeline-item copane-timeline-item--active'
+            : isConcluida
+            ? 'copane-timeline-item copane-timeline-item--done'
+            : 'copane-timeline-item';
+
+        const badge = isProxima
+            ? '<span class="copane-timeline-badge">em andamento</span>'
+            : isConcluida
+            ? '<span class="copane-timeline-badge copane-timeline-badge--done">concluída</span>'
+            : '';
+
+        return `
+        <div class="${cls}">
+            <p class="copane-timeline-fase">${f.fase}${badge}</p>
+            <p class="copane-timeline-info">${f.info} &bull; ${f.times}</p>
+        </div>`;
+    }).join('');
+}
+
+// ═══════════════════════════════════════════════════
+// NOTÍCIAS
+// ═══════════════════════════════════════════════════
+
+async function carregarNoticias() {
+    const container = document.getElementById('copane-noticias-lista');
+    if (!container) return;
+
+    try {
+        const res = await fetch('/api/noticias/copa-nordeste');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+
+        if (data.success && Array.isArray(data.noticias) && data.noticias.length > 0) {
+            container.innerHTML = data.noticias.map(n => {
+                const link = (n.link || '').replace(/"/g, '&quot;');
+                const titulo = (n.titulo || '').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                const fonte = n.fonte || 'Notícia';
+                const tempo = n.tempoRelativo ? `<span class="copane-noticia-tempo">${n.tempoRelativo}</span>` : '';
+                return `
+                <div class="copane-noticia-card"
+                     onclick="window.open('${link}', '_blank')"
+                     role="link" tabindex="0">
+                    <div class="copane-noticia-icon">
+                        <span class="material-icons">article</span>
+                    </div>
+                    <div class="copane-noticia-text">
+                        <p class="copane-noticia-title">${titulo}</p>
+                        <div class="copane-noticia-meta">
+                            <span class="copane-noticia-fonte">${fonte}</span>
+                            ${tempo}
+                        </div>
+                    </div>
+                    <span class="material-icons copane-noticia-chevron">chevron_right</span>
+                </div>`;
+            }).join('');
+        } else {
+            container.innerHTML = renderizarNoticiasFallback();
+        }
+    } catch (err) {
+        if (window.Log) Log.warn('COPA-NORDESTE', 'Erro ao carregar notícias:', err);
+        container.innerHTML = renderizarNoticiasFallback();
+    }
+}
+
+function renderizarNoticiasFallback() {
+    return `
+    <div class="copane-noticia-card">
+        <div class="copane-noticia-icon">
+            <span class="material-icons">emoji_events</span>
+        </div>
+        <div class="copane-noticia-text">
+            <p class="copane-noticia-title">Copa do Nordeste 2026 — O Nordestão com novo formato: 20 clubes e 4 grupos</p>
+            <div class="copane-noticia-meta">
+                <span class="copane-noticia-fonte">Liga do Nordeste</span>
+            </div>
+        </div>
+    </div>
+    <div class="copane-noticia-card">
+        <div class="copane-noticia-icon">
+            <span class="material-icons">groups</span>
+        </div>
+        <div class="copane-noticia-text">
+            <p class="copane-noticia-title">Fortaleza, Vitória, Ceará e Sport são os destaques da 23ª edição do torneio regional</p>
+            <div class="copane-noticia-meta">
+                <span class="copane-noticia-fonte">Copa do Nordeste 2026</span>
+            </div>
+        </div>
+    </div>`;
+}

--- a/public/participante/js/participante-navigation.js
+++ b/public/participante/js/participante-navigation.js
@@ -74,6 +74,7 @@ class ParticipanteNavigation {
             "agenda-tabelas": "/participante/fronts/agenda-tabelas.html",
             "libertadores": "/participante/fronts/libertadores.html",
             "copa-brasil": "/participante/fronts/copa-brasil.html",
+            "copa-nordeste": "/participante/fronts/copa-nordeste.html",
         };
 
         // ✅ v3.0: Controles simplificados (apenas debounce por tempo)
@@ -561,7 +562,7 @@ class ParticipanteNavigation {
      */
     _isModuloOpcionalInativo(moduloId) {
         // Módulos de sistema/base: sempre permitidos (inclui sub-módulos como rodada-xray)
-        const modulosPermitidos = ['home', 'boas-vindas', 'extrato', 'ranking', 'rodadas', 'rodada-xray', 'historico', 'configuracoes', 'copa-times-sc', 'copa-2026-mundo', 'regras', 'libertadores', 'copa-brasil', 'info-meu-time', 'agenda-tabelas'];
+        const modulosPermitidos = ['home', 'boas-vindas', 'extrato', 'ranking', 'rodadas', 'rodada-xray', 'historico', 'configuracoes', 'copa-times-sc', 'copa-2026-mundo', 'regras', 'libertadores', 'copa-brasil', 'copa-nordeste', 'info-meu-time', 'agenda-tabelas'];
         if (modulosPermitidos.includes(moduloId)) return false;
 
         // Sem dados de módulos carregados: permitir (graceful degradation)
@@ -1122,6 +1123,7 @@ class ParticipanteNavigation {
             "tiro-certo": "/participante/js/modules/participante-tiro-certo.js",
             "libertadores": "/participante/js/modules/participante-libertadores.js",
             "copa-brasil": "/participante/js/modules/participante-copa-brasil.js",
+            "copa-nordeste": "/participante/js/modules/participante-copa-nordeste.js",
             "agenda-tabelas": "/participante/js/modules/participante-agenda-tabelas.js",
             "info-meu-time": "/participante/js/modules/participante-info-meu-time.js",
         };

--- a/routes/noticias-time-routes.js
+++ b/routes/noticias-time-routes.js
@@ -17,6 +17,10 @@ const CACHE_TTL = 30 * 60 * 1000; // 30 minutos
 let cacheLibertadores = null;
 const CACHE_TTL_LIBERTA = 60 * 60 * 1000; // 1 hora
 
+// Cache separado para Copa do Nordeste
+let cacheCopaNordeste = null;
+const CACHE_TTL_COPANE = 60 * 60 * 1000; // 1 hora
+
 /**
  * Extrai texto limpo de um possível CDATA ou HTML
  */
@@ -220,6 +224,55 @@ async function buscarNoticiasLibertadores() {
     }
 }
 
+/**
+ * Busca notícias da Copa do Nordeste via Google News RSS
+ */
+async function buscarNoticiasCopaNordeste() {
+    // Verificar cache
+    if (cacheCopaNordeste && (Date.now() - cacheCopaNordeste.timestamp) < CACHE_TTL_COPANE) {
+        return { noticias: cacheCopaNordeste.noticias, cache: true };
+    }
+
+    try {
+        const query = encodeURIComponent('Copa do Nordeste 2026');
+        const url = `https://news.google.com/rss/search?q=${query}&hl=pt-BR&gl=BR&ceid=BR:pt-419`;
+
+        console.log('[NOTICIAS] Buscando notícias da Copa do Nordeste 2026...');
+
+        const response = await fetch(url, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (compatible; SuperCartolaManager/1.0)',
+                'Accept': 'application/rss+xml, application/xml, text/xml'
+            },
+            timeout: 10000
+        });
+
+        if (!response.ok) {
+            console.error(`[NOTICIAS] Erro HTTP ${response.status} ao buscar Copa do Nordeste`);
+            if (cacheCopaNordeste) {
+                return { noticias: cacheCopaNordeste.noticias, cache: true, stale: true };
+            }
+            return { noticias: [], erro: 'Falha ao buscar notícias' };
+        }
+
+        const xml = await response.text();
+        const noticias = parseRSSItems(xml).slice(0, 6); // Máximo 6 notícias
+
+        console.log(`[NOTICIAS] ${noticias.length} notícias da Copa do Nordeste encontradas`);
+
+        // Atualizar cache
+        cacheCopaNordeste = { noticias, timestamp: Date.now() };
+
+        return { noticias, cache: false };
+    } catch (error) {
+        console.error('[NOTICIAS] Erro ao buscar Copa do Nordeste:', error.message);
+        if (cacheCopaNordeste) {
+            return { noticias: cacheCopaNordeste.noticias, cache: true, stale: true };
+        }
+        return { noticias: [], erro: error.message };
+    }
+}
+
 // ┌──────────────────────────────────────────────────────────────────────┐
 // │ ROTAS                                                                │
 // └──────────────────────────────────────────────────────────────────────┘
@@ -273,6 +326,28 @@ router.get('/libertadores', async (req, res) => {
     } catch (error) {
         console.error('[NOTICIAS] Erro na rota libertadores:', error);
         res.status(500).json({ success: false, erro: 'Erro ao buscar notícias da Libertadores' });
+    }
+});
+
+/**
+ * GET /api/noticias/copa-nordeste
+ * Retorna notícias da Copa do Nordeste 2026 via Google News RSS
+ */
+router.get('/copa-nordeste', async (req, res) => {
+    try {
+        const resultado = await buscarNoticiasCopaNordeste();
+
+        res.json({
+            success: true,
+            noticias: resultado.noticias,
+            total: resultado.noticias.length,
+            cache: resultado.cache || false,
+            stale: resultado.stale || false,
+            atualizadoEm: new Date().toISOString()
+        });
+    } catch (error) {
+        console.error('[NOTICIAS] Erro na rota copa-nordeste:', error);
+        res.status(500).json({ success: false, erro: 'Erro ao buscar notícias da Copa do Nordeste' });
     }
 });
 


### PR DESCRIPTION
## 📋 Resumo da Alteração

Implementação completa da Landing Page dedicada à Copa do Nordeste 2026, incluindo:

- **Nova página temática** com hero section, status dinâmico e informações da competição
- **Seção de Grupos**: Grid 2x2 exibindo os 4 grupos com 5 times cada
- **Timeline de Fases**: Visualização das 4 fases da competição (Grupos, Quartas, Semifinais, Final)
- **Integração de Notícias**: Carregamento dinâmico via Google News RSS com cache de 1 hora
- **Design coeso**: Paleta de cores temática (Verde/Laranja/Dourado) com tokens CSS reutilizáveis
- **Atualização Copa do Brasil**: Adição de seção de confrontos da 5ª Fase com sorteio de 23/03/2026

## 🎯 Módulo Afetado

- [x] Outro: **Landing Pages de Competições Regionais**

## 🔧 Arquivos Modificados

### Novos Arquivos
- `public/participante/css/copa-nordeste-lp.css` - Estilos completos da LP (509 linhas, mobile-first, dark theme)
- `public/participante/js/modules/participante-copa-nordeste.js` - Controller com dados de grupos, fases e integração de notícias
- `public/participante/fronts/copa-nordeste.html` - Template HTML da página

### Modificados
- `routes/noticias-time-routes.js` - Adição de rota `/api/noticias/copa-nordeste` com busca RSS e cache
- `public/participante/css/_app-tokens.css` - Novos tokens de cor para Copa do Nordeste (`--app-copane-*`)
- `public/participante/js/participante-navigation.js` - Registro da rota de navegação SPA
- `public/participante/css/copa-brasil-lp.css` - Adição de estilos para seção de confrontos da 5ª Fase
- `public/participante/js/modules/participante-copa-brasil.js` - Dados dos 16 confrontos do sorteio + renderização
- `public/participante/fronts/copa-brasil.html` - Nova seção de confrontos da 5ª Fase

## ✅ Como Testar

1. Acesse: `/participante#copa-nordeste`
2. Valide:
   - Hero section com troféu, título e chips de status
   - Stats strip mostrando 20 clubes, 4 grupos, 23ª edição, final em 7 Jun
   - Grid de 4 grupos com times destacados (Vitória, CRB, Ceará/Sport, Fortaleza)
   - Timeline com 4 fases (Grupos, Quartas, Semifinais, Final)
   - Notícias carregadas via `/api/noticias/copa-nordeste`
3. Acesse: `/participante#copa-brasil`
4. Valide: Nova seção "5ª Fase — Confrontos" com 16 jogos do sorteio

## ✨ Checklist

- [x] Testado localmente
- [x] Sem breaking changes
- [x] Reutiliza tokens CSS existentes
- [x] Cache de notícias implementado (1 hora)
- [x] Fallback de notícias em caso de erro
- [x] Responsivo mobile-first

https://claude.ai/code/session_0168nznfqVRHrYuH8g1kaSCj