### PR TITLE
feat(copa-nordeste): live experience — polling adaptativo + endpoint ao-vivo

### DIFF
--- a/public/participante/css/copa-nordeste-lp.css
+++ b/public/participante/css/copa-nordeste-lp.css
@@ -159,6 +159,20 @@
 }
 .copane-chip--next .material-icons { color: var(--app-copane-primary, #E65100); }
 
+.copane-chip--live {
+    background: rgba(239, 68, 68, 0.1);
+    border-color: rgba(239, 68, 68, 0.4);
+    color: #fca5a5;
+}
+.copane-chip--live .material-icons { color: var(--app-danger, #ef4444); }
+
+.copane-chip--stale {
+    background: rgba(245, 158, 11, 0.1);
+    border-color: rgba(245, 158, 11, 0.35);
+    color: #fcd34d;
+}
+.copane-chip--stale .material-icons { color: #f59e0b; }
+
 .copane-chip--event {
     background: var(--app-copane-muted, rgba(230, 81, 0, 0.15));
     border-color: var(--app-copane-border, rgba(230, 81, 0, 0.35));
@@ -548,6 +562,29 @@
 .copane-jogo-card--live {
     border-color: var(--app-copane-primary, #E65100);
     background: rgba(230, 81, 0, 0.08);
+}
+
+/* Live dot — pulsing indicator */
+.copane-live-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--app-danger, #ef4444);
+    animation: copane-live-pulse 1.5s ease-in-out infinite;
+    flex-shrink: 0;
+}
+
+.copane-live-dot--small {
+    width: 6px;
+    height: 6px;
+    position: absolute;
+    top: 0.35rem;
+    left: 0.4rem;
+}
+
+@keyframes copane-live-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.4; transform: scale(0.8); }
 }
 
 .copane-jogo-time {

--- a/public/participante/fronts/copa-nordeste.html
+++ b/public/participante/fronts/copa-nordeste.html
@@ -110,4 +110,4 @@
     <div class="pb-24"></div>
 </div>
 
-<link rel="stylesheet" href="/participante/css/copa-nordeste-lp.css?v=2">
+<link rel="stylesheet" href="/participante/css/copa-nordeste-lp.css?v=3">

--- a/public/participante/js/modules/participante-copa-nordeste.js
+++ b/public/participante/js/modules/participante-copa-nordeste.js
@@ -1,10 +1,11 @@
 // participante-copa-nordeste.js
-// v2.0 - Controller da Landing Page "Copa do Nordeste 2026"
+// v3.0 - Controller da Landing Page "Copa do Nordeste 2026"
+// v3.0: Live Experience — polling adaptativo, endpoint /ao-vivo, indicadores live/stale
 // v2.0: Dados dinâmicos via /api/competicao/copa-nordeste (SoccerDataAPI + Globo)
 //       Fallback: dados hardcoded para quando API ainda não tem dados
 //
 // Fontes de dados:
-//   - API: /api/competicao/copa-nordeste/resumo (classificação, resultados, próximos jogos)
+//   - API: /api/competicao/copa-nordeste/ao-vivo (atualiza MongoDB + retorna dados frescos)
 //   - API: /api/noticias/copa-nordeste (Google News RSS, cache 1h)
 //   - Fallback: dados estáticos hardcoded abaixo
 
@@ -49,11 +50,22 @@ const FASES_COPA_NORDESTE = [
 let dadosAPI = null;
 
 // ═══════════════════════════════════════════════════
+// POLLING & LIVE STATE
+// ═══════════════════════════════════════════════════
+
+let _pollingTimer = null;
+let _lastUpdateTs = null;
+let _isLive = false;
+const POLL_NORMAL_MS = 60_000;          // 60s sem jogos ao vivo
+const POLL_LIVE_MS = 30_000;            // 30s com jogos ao vivo
+const STALE_THRESHOLD_MS = 5 * 60_000;  // 5min = warning de dados desatualizados
+
+// ═══════════════════════════════════════════════════
 // INICIALIZAÇÃO
 // ═══════════════════════════════════════════════════
 
 export async function inicializarCopaNordesteParticipante(params) {
-    if (window.Log) Log.info('COPA-NORDESTE', 'Inicializando LP Copa do Nordeste 2026 v2.0...');
+    if (window.Log) Log.info('COPA-NORDESTE', 'Inicializando LP Copa do Nordeste 2026 v3.0...');
 
     window.destruirCopaNordesteParticipante = destruirCopaNordesteParticipante;
 
@@ -65,11 +77,17 @@ export async function inicializarCopaNordesteParticipante(params) {
         ]);
 
         dadosAPI = apiData;
+        _lastUpdateTs = Date.now();
+        _isLive = !!(dadosAPI?.tem_jogos_ao_vivo);
 
         renderizarInfoHero();
         renderizarGrupos();
         renderizarResultados();
         renderizarFases();
+        _atualizarStatsStrip();
+
+        // Iniciar polling adaptativo
+        _iniciarPolling();
 
         if (window.Log) Log.info('COPA-NORDESTE', dadosAPI ? 'LP com dados dinâmicos' : 'LP com dados estáticos (fallback)');
     } catch (erro) {
@@ -78,16 +96,63 @@ export async function inicializarCopaNordesteParticipante(params) {
 }
 
 export function destruirCopaNordesteParticipante() {
+    _pararPolling();
     dadosAPI = null;
+    _lastUpdateTs = null;
+    _isLive = false;
 }
 
 // ═══════════════════════════════════════════════════
-// API DINÂMICA
+// POLLING ADAPTATIVO
+// ═══════════════════════════════════════════════════
+
+function _iniciarPolling() {
+    _pararPolling();
+    const intervalo = _isLive ? POLL_LIVE_MS : POLL_NORMAL_MS;
+    _pollingTimer = setInterval(_atualizarDados, intervalo);
+    if (window.Log) Log.info('COPA-NORDESTE', `Polling ativo: ${intervalo / 1000}s (${_isLive ? 'LIVE' : 'normal'})`);
+}
+
+function _pararPolling() {
+    if (_pollingTimer) {
+        clearInterval(_pollingTimer);
+        _pollingTimer = null;
+    }
+}
+
+async function _atualizarDados() {
+    try {
+        const apiData = await carregarDadosAPI();
+        if (!apiData) return; // Falha silenciosa — mantém dados anteriores
+
+        dadosAPI = apiData;
+        _lastUpdateTs = Date.now();
+
+        // Detectar mudança de estado live → ajustar intervalo
+        const eraLive = _isLive;
+        _isLive = !!(dadosAPI?.tem_jogos_ao_vivo);
+        if (_isLive !== eraLive) {
+            _iniciarPolling(); // reiniciar com novo intervalo
+        }
+
+        // Re-renderizar seções afetadas
+        renderizarInfoHero();
+        renderizarGrupos();
+        renderizarResultados();
+        renderizarFases();
+        _atualizarStatsStrip();
+    } catch (err) {
+        if (window.Log) Log.warn('COPA-NORDESTE', 'Erro no polling:', err.message);
+    }
+}
+
+// ═══════════════════════════════════════════════════
+// API DINÂMICA — /ao-vivo (atualiza MongoDB + retorna dados frescos)
 // ═══════════════════════════════════════════════════
 
 async function carregarDadosAPI() {
     try {
-        const res = await fetch('/api/competicao/copa-nordeste/resumo');
+        const res = await fetch('/api/competicao/copa-nordeste/ao-vivo');
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
 
@@ -102,7 +167,7 @@ async function carregarDadosAPI() {
 }
 
 // ═══════════════════════════════════════════════════
-// INFO HERO
+// INFO HERO — com indicadores live + stale
 // ═══════════════════════════════════════════════════
 
 function renderizarInfoHero() {
@@ -112,9 +177,10 @@ function renderizarInfoHero() {
     const evento = proximoEvento();
     let html = '';
 
-    // Se tem dados da API, mostrar info real
+    // Chip de jogos ao vivo com live dot pulsante
     if (dadosAPI?.tem_jogos_ao_vivo) {
-        html += `<div class="copane-chip copane-chip--next">
+        html += `<div class="copane-chip copane-chip--live">
+            <span class="copane-live-dot"></span>
             <span class="material-icons">sports_soccer</span>
             Jogos ao vivo agora
         </div>`;
@@ -136,17 +202,67 @@ function renderizarInfoHero() {
         </div>`;
     }
 
-    // Indicador de dados dinâmicos
-    if (dadosAPI?.ultima_atualizacao) {
-        const atualizado = new Date(dadosAPI.ultima_atualizacao);
-        const tempoStr = atualizado.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
-        html += `<div class="copane-chip copane-chip--done">
-            <span class="material-icons">sync</span>
-            Dados atualizados ${tempoStr}
-        </div>`;
+    // Indicador de atualização com detecção de stale
+    if (_lastUpdateTs) {
+        const diffMs = Date.now() - _lastUpdateTs;
+        const isStale = diffMs > STALE_THRESHOLD_MS;
+        const atualizacao = dadosAPI?.ultima_atualizacao
+            ? new Date(dadosAPI.ultima_atualizacao)
+            : new Date(_lastUpdateTs);
+        const tempoStr = atualizacao.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+
+        if (isStale) {
+            html += `<div class="copane-chip copane-chip--stale">
+                <span class="material-icons">warning</span>
+                Dados podem estar desatualizados (${tempoStr})
+            </div>`;
+        } else {
+            html += `<div class="copane-chip copane-chip--done">
+                <span class="material-icons">sync</span>
+                Atualizado ${tempoStr}
+            </div>`;
+        }
     }
 
     container.innerHTML = html;
+}
+
+// ═══════════════════════════════════════════════════
+// STATS STRIP DINÂMICO
+// ═══════════════════════════════════════════════════
+
+function _atualizarStatsStrip() {
+    if (!dadosAPI?.stats) return;
+
+    const items = document.querySelectorAll('.copane-stat-item');
+    if (items.length < 4) return;
+
+    const { jogos_realizados, fase_atual } = dadosAPI.stats;
+
+    // Item[2]: trocar "23ª Edição" → jogos realizados
+    if (typeof jogos_realizados === 'number') {
+        const val2 = items[2].querySelector('.copane-stat-value');
+        const lbl2 = items[2].querySelector('.copane-stat-label');
+        if (val2 && lbl2) {
+            val2.textContent = `${jogos_realizados}`;
+            lbl2.textContent = 'Jogos';
+        }
+    }
+
+    // Item[3]: trocar "7 Jun Final" → fase atual
+    if (fase_atual) {
+        const val3 = items[3].querySelector('.copane-stat-value');
+        const lbl3 = items[3].querySelector('.copane-stat-label');
+        if (val3 && lbl3) {
+            const faseLabel = fase_atual === 'grupos' ? 'Grupos'
+                : fase_atual === 'quartas' ? 'Quartas'
+                : fase_atual === 'semis' ? 'Semis'
+                : fase_atual === 'final' ? 'Final'
+                : fase_atual;
+            val3.textContent = faseLabel;
+            lbl3.textContent = 'Fase Atual';
+        }
+    }
 }
 
 // ═══════════════════════════════════════════════════
@@ -242,9 +358,11 @@ function renderizarJogoCard(jogo, aoVivo) {
         : jogo.horario || 'A definir';
     const dataStr = jogo.data ? new Date(jogo.data + 'T12:00:00').toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' }) : '';
     const liveClass = aoVivo ? ' copane-jogo--live' : '';
+    const liveDot = aoVivo ? '<span class="copane-live-dot copane-live-dot--small"></span>' : '';
 
     return `
     <div class="copane-jogo-card${liveClass}">
+        ${liveDot}
         <span class="copane-jogo-time">${jogo.mandante}</span>
         <span class="copane-jogo-placar">${placar}</span>
         <span class="copane-jogo-time">${jogo.visitante}</span>


### PR DESCRIPTION
## Summary

- **Fix principal**: LP chamava `/api/competicao/copa-nordeste/resumo` (leitura estática do MongoDB) — jogos encerrados não apareciam. Trocado para `/ao-vivo` que dispara pipeline completo (SoccerDataAPI + Globo → MongoDB → dados frescos)
- **Polling adaptativo**: 60s normal, 30s quando há jogos ao vivo. Cleanup automático no destroy
- **Indicadores visuais**: live dot pulsante (vermelho), chip "Atualizado HH:MM", warning amber quando dados > 5min sem update
- **Stats strip dinâmico**: substitui valores hardcoded por jogos realizados e fase atual da API
- **CSS namespaced**: `copane-live-dot`, `copane-chip--live/stale`, keyframe `copane-live-pulse`

## Arquivos modificados

| Arquivo | Mudança |
|---------|---------|
| `participante-copa-nordeste.js` | v2.0→v3.0: endpoint `/ao-vivo`, polling, live indicators, stats dinâmico |
| `copa-nordeste-lp.css` | Live dot pulse, chip--live, chip--stale styles |
| `copa-nordeste.html` | Cache bust `?v=3` |

## Test plan

- [ ] Abrir LP Copa do Nordeste e verificar que chama `/api/competicao/copa-nordeste/ao-vivo` no Network
- [ ] Verificar que jogos encerrados aparecem em "Últimos Resultados"
- [ ] Verificar chip "Atualizado HH:MM" no hero
- [ ] Verificar polling a cada 60s no console (log "Polling ativo: 60s")
- [ ] Navegar para outra página e voltar — verificar que destroy limpa polling e init recria
- [ ] Se houver jogos ao vivo: live dot pulsante + polling reduzido para 30s

https://claude.ai/code/session_0171fKL9cD61gmccz9zSroTQ