### PR TITLE
feat(especial): preview de resultados nas cards do sheet Especial

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,7 @@ import rodadasCorrecaoRoutes from "./routes/rodadasCorrecaoRoutes.js";
 import calendarioRodadasRoutes from "./routes/calendario-rodadas-routes.js";
 import brasileiraoTabelaRoutes from "./routes/brasileirao-tabela-routes.js";
 import competicaoRoutes from "./routes/competicao-routes.js";
+import competicaoService from "./services/competicao-service.js";
 import golsRoutes from "./routes/gols.js";
 import artilheiroCampeaoRoutes from "./routes/artilheiro-campeao-routes.js";
 import luvaDeOuroRoutes from "./routes/luva-de-ouro-routes.js";
@@ -1092,6 +1093,23 @@ initAsyncPromise = (async () => {
   });
   cronJobs.push(cronLimpezaCache);
   console.log("[SERVER] 🔔 Cron de limpeza de cache agendado (diário 4h)");
+
+  // ⚽ CRON: Persistir resultados das competições Especial (Opção C)
+  // Roda a cada 5 min na janela de jogos (17h-23h BRT = 20h-02h UTC)
+  // Garante status agendado→encerrado no MongoDB independente de usuário ativo
+  const COMPETICOES_ESPECIAIS = ["copa-nordeste", "copa-brasil", "libertadores"];
+  const temporadaAtual = new Date().getFullYear();
+  const cronCompeticoes = cron.schedule("*/5 20-23,0-2 * * *", async () => {
+    for (const slug of COMPETICOES_ESPECIAIS) {
+      try {
+        await competicaoService.obterResumoAoVivo(slug, temporadaAtual);
+      } catch (err) {
+        console.error(`[CRON-COMPETICOES] Erro ao sincronizar ${slug}:`, err.message);
+      }
+    }
+  });
+  cronJobs.push(cronCompeticoes);
+  console.log("[SERVER] ⚽ Cron de competições Especial agendado (*/5 20h-02h UTC)");
 })().catch((err) => {
   const logFatal = IS_PRODUCTION ? originalConsole.error : console.error;
   logFatal("[INIT-ASYNC] ❌ ERRO FATAL na inicialização assíncrona:", err.message);

--- a/public/participante/css/quick-access-bar.css
+++ b/public/participante/css/quick-access-bar.css
@@ -574,6 +574,41 @@
     color: rgba(255, 255, 255, 0.25);
 }
 
+/* ─── Preview de resultado nas cards Especial ─────────────────────────── */
+
+@keyframes especial-pulse-live {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50%       { opacity: 0.4; transform: scale(0.7); }
+}
+
+/* Live dot pulsante */
+.especial-live-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: var(--app-radius-full, 9999px);
+    background: var(--app-color-danger, #ef4444);
+    margin-right: 5px;
+    vertical-align: middle;
+    animation: especial-pulse-live 1.4s ease-in-out infinite;
+}
+
+/* Card com jogo ao vivo — borda e brilho sutil */
+.especial-card--live {
+    box-shadow: 0 0 0 1px var(--app-color-danger, #ef4444), 0 0 12px rgba(239, 68, 68, 0.2);
+}
+.especial-card--live .especial-card-desc {
+    color: var(--app-color-danger, #ef4444);
+    font-weight: 500;
+}
+
+/* Com preview: desc em destaque (resultado ou próximo) */
+.especial-card--com-preview .especial-card-desc {
+    color: var(--app-text-white, #fff);
+    font-size: 10px;
+    letter-spacing: 0.3px;
+}
+
 /* =====================================================================
    AJUSTE DO CONTAINER PRINCIPAL
    ===================================================================== */

--- a/public/participante/js/modules/participante-libertadores.js
+++ b/public/participante/js/modules/participante-libertadores.js
@@ -119,7 +119,7 @@ async function carregarDadosAPILiberta() {
         const res = await fetch('/api/competicao/libertadores/resumo');
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
-        return (data.success && (data.grupos?.length > 0 || data.ultimos_resultados?.length > 0)) ? data : null;
+        return (data.success && (data.grupos?.length > 0 || data.ultimos_resultados?.length > 0 || data.proximos_jogos?.length > 0)) ? data : null;
     } catch (err) {
         if (window.Log) Log.warn('LIBERTADORES', 'API indisponível, usando fallback:', err.message);
         return null;

--- a/public/participante/js/participante-quick-bar.js
+++ b/public/participante/js/participante-quick-bar.js
@@ -38,6 +38,10 @@ class QuickAccessBar {
         // Touch state
         this._touchStartY = 0;
         this._isAnimating = false;
+
+        // Cache de previews das competições Especial (TTL: 60s)
+        this._especialPreviewCache = {};
+        this._ESPECIAL_PREVIEW_TTL = 60_000;
     }
 
     async inicializar() {
@@ -517,6 +521,9 @@ class QuickAccessBar {
             setTimeout(() => {
                 this._isAnimating = false;
             }, 350);
+
+            // Preview de resultados: fire-and-forget após animação (não bloqueia abertura)
+            setTimeout(() => this._carregarPreviewsEspeciais(), 200);
         });
     }
 
@@ -716,6 +723,116 @@ class QuickAccessBar {
 
         if (window.Log) Log.debug('QUICK-BAR', `Modal "Aguarde" exibido para: ${moduloId}`);
     }
+
+    // ═══════════════════════════════════════════════════
+    // PREVIEWS DE RESULTADOS NAS CARDS DO SHEET ESPECIAL
+    // ═══════════════════════════════════════════════════
+
+    /**
+     * Busca dados de cada competição e injeta mini-preview nas cards.
+     * Fire-and-forget: não bloqueia abertura do sheet.
+     * Cache de 60s para não re-buscar a cada abertura.
+     */
+    async _carregarPreviewsEspeciais() {
+        const competicoes = [
+            { slug: 'copa-nordeste', selector: '.especial-card-copane' },
+            { slug: 'copa-brasil',   selector: '.especial-card-copabr' },
+            { slug: 'libertadores',  selector: '.especial-card-liberta' },
+        ];
+
+        for (const { slug, selector } of competicoes) {
+            const cached = this._especialPreviewCache[slug];
+            if (cached && (Date.now() - cached.ts) < this._ESPECIAL_PREVIEW_TTL) {
+                this._injetarPreviewCard(selector, cached.preview);
+                continue;
+            }
+
+            fetch(`/api/competicao/${slug}/ao-vivo`)
+                .then(r => r.ok ? r.json() : null)
+                .then(data => {
+                    if (!data?.success) return;
+                    const preview = this._gerarTextoPreview(data);
+                    this._especialPreviewCache[slug] = { preview, ts: Date.now() };
+                    this._injetarPreviewCard(selector, preview);
+                })
+                .catch(() => {});
+        }
+    }
+
+    /**
+     * Gera objeto de preview com base nos dados da competição.
+     * Retorna { isLive, texto } ou null se sem dados.
+     */
+    _gerarTextoPreview(data) {
+        // 1. Jogo ao vivo
+        if (data.jogos_ao_vivo?.length > 0) {
+            const j = data.jogos_ao_vivo[0];
+            const m = _abreviarTime(j.mandante);
+            const v = _abreviarTime(j.visitante);
+            const placar = (j.placar_mandante !== null)
+                ? `${j.placar_mandante} × ${j.placar_visitante}`
+                : 'vs';
+            return { isLive: true, texto: `${m} ${placar} ${v}` };
+        }
+
+        // 2. Último resultado
+        if (data.ultimos_resultados?.length > 0) {
+            const j = data.ultimos_resultados[0];
+            const m = _abreviarTime(j.mandante);
+            const v = _abreviarTime(j.visitante);
+            return { isLive: false, texto: `${m} ${j.placar_mandante} × ${j.placar_visitante} ${v}` };
+        }
+
+        // 3. Próximo jogo
+        if (data.proximos_jogos?.length > 0) {
+            const j = data.proximos_jogos[0];
+            const m = _abreviarTime(j.mandante);
+            const v = _abreviarTime(j.visitante);
+            const hora = j.horario ? ` · ${j.horario}` : '';
+            return { isLive: false, texto: `Próx: ${m} vs ${v}${hora}` };
+        }
+
+        return null;
+    }
+
+    /**
+     * Injeta o preview na .especial-card-desc usando textContent (XSS-safe).
+     * O live dot é criado via DOM, não innerHTML.
+     */
+    _injetarPreviewCard(selector, preview) {
+        if (!preview) return;
+        const sheet = this._dom.menuSheet;
+        if (!sheet) return;
+        const desc = sheet.querySelector(`${selector} .especial-card-desc`);
+        if (!desc) return;
+
+        // Limpa conteúdo anterior
+        desc.textContent = '';
+
+        if (preview.isLive) {
+            const dot = document.createElement('span');
+            dot.className = 'especial-live-dot';
+            desc.appendChild(dot);
+        }
+
+        const txt = document.createTextNode(preview.texto);
+        desc.appendChild(txt);
+
+        const card = sheet.querySelector(selector);
+        if (card) {
+            card.classList.add('especial-card--com-preview');
+            if (preview.isLive) card.classList.add('especial-card--live');
+        }
+    }
+}
+
+// ─── Helper: abreviação de nome de time ────────────────────────────────────
+function _abreviarTime(nome) {
+    if (!nome) return '';
+    if (nome.length <= 8) return nome;
+    const palavras = nome.split(/[\s\-]+/);
+    if (palavras.length >= 2) return palavras.map(p => p[0]).join('').toUpperCase().substring(0, 3);
+    return nome.substring(0, 6);
 }
 
 // Singleton instance

--- a/services/competicao-service.js
+++ b/services/competicao-service.js
@@ -6,6 +6,7 @@
 // =====================================================================
 
 import CalendarioCompeticao from '../models/CalendarioCompeticao.js';
+import { obterJogosGloboMultiDatas } from '../scripts/scraper-jogos-globo.js';
 
 // =====================================================================
 // CONFIGURAÇÃO
@@ -235,6 +236,116 @@ async function atualizarPlacaresAoVivo(competicao, temporada, jogosAoVivo) {
 }
 
 // =====================================================================
+// SYNC MULTI-DATAS (resultados históricos via Globo ~5 dias)
+// =====================================================================
+
+/**
+ * Sincroniza resultados de múltiplos dias usando obterJogosGloboMultiDatas.
+ * Captura jogos encerrados de dias anteriores que nunca foram persistidos.
+ * Chamada em obterResumoAoVivo para garantir que resultados passados
+ * (window de ~2 dias anteriores da Globo) sempre entrem no MongoDB.
+ */
+async function sincronizarMultiDatas(competicao, temporada) {
+    let dadosPorData;
+    try {
+        dadosPorData = await obterJogosGloboMultiDatas();
+    } catch (err) {
+        console.warn(`[COMPETICAO-SERVICE] sincronizarMultiDatas falhou ao buscar Globo:`, err.message);
+        return { sincronizados: 0 };
+    }
+
+    let calendarioDoc = await CalendarioCompeticao.findOne({ competicao, temporada });
+    let mudancas = 0;
+
+    for (const [data, jogos] of Object.entries(dadosPorData)) {
+        const jogosComp = jogos.filter(j => ligaCorresponde(j.liga || j.ligaOriginal, competicao));
+        if (jogosComp.length === 0) continue;
+
+        for (const jogo of jogosComp) {
+            const novoStatus = converterStatus(jogo.statusRaw);
+            if (!novoStatus) continue;
+
+            // Criar documento se ainda não existir
+            if (!calendarioDoc) {
+                calendarioDoc = new CalendarioCompeticao({ competicao, temporada, partidas: [] });
+            }
+
+            // Match por id_externo
+            let idx = -1;
+            if (jogo.id) {
+                idx = calendarioDoc.partidas.findIndex(p => p.id_externo === String(jogo.id));
+            }
+
+            // Fallback: match por nomes normalizados + data do jogo
+            if (idx < 0) {
+                const normM = normalizar(jogo.mandante);
+                const normV = normalizar(jogo.visitante);
+                idx = calendarioDoc.partidas.findIndex(p => {
+                    if (p.data !== data) return false;
+                    const pM = normalizar(p.mandante);
+                    const pV = normalizar(p.visitante);
+                    return (pM.includes(normM) || normM.includes(pM)) &&
+                           (pV.includes(normV) || normV.includes(pV));
+                });
+            }
+
+            if (idx < 0) {
+                // Jogo não existe — adicionar
+                calendarioDoc.partidas.push({
+                    id_externo: jogo.id ? String(jogo.id) : null,
+                    fase: null,
+                    grupo: null,
+                    data,
+                    horario: jogo.horario || '00:00',
+                    mandante: jogo.mandante,
+                    visitante: jogo.visitante,
+                    placar_mandante: typeof jogo.golsMandante === 'number' ? jogo.golsMandante : null,
+                    placar_visitante: typeof jogo.golsVisitante === 'number' ? jogo.golsVisitante : null,
+                    status: novoStatus,
+                    estadio: jogo.estadio || null,
+                });
+                mudancas++;
+                continue;
+            }
+
+            // Jogo existe — atualizar se mudou
+            const partida = calendarioDoc.partidas[idx];
+            let mudou = false;
+
+            if (partida.status !== novoStatus) {
+                partida.status = novoStatus;
+                mudou = true;
+            }
+            if (novoStatus === 'encerrado' || novoStatus === 'ao_vivo') {
+                if (typeof jogo.golsMandante === 'number' && partida.placar_mandante !== jogo.golsMandante) {
+                    partida.placar_mandante = jogo.golsMandante;
+                    mudou = true;
+                }
+                if (typeof jogo.golsVisitante === 'number' && partida.placar_visitante !== jogo.golsVisitante) {
+                    partida.placar_visitante = jogo.golsVisitante;
+                    mudou = true;
+                }
+            }
+            if (!partida.id_externo && jogo.id) {
+                partida.id_externo = String(jogo.id);
+                mudou = true;
+            }
+            if (mudou) mudancas++;
+        }
+    }
+
+    if (mudancas > 0 && calendarioDoc) {
+        calendarioDoc.ultima_atualizacao = new Date();
+        calendarioDoc.atualizarStats?.();
+        calendarioDoc.calcularClassificacao?.();
+        await calendarioDoc.save();
+        console.log(`[COMPETICAO-SERVICE] ${competicao}: ${mudancas} partidas sincronizadas via multi-datas Globo`);
+    }
+
+    return { sincronizados: mudancas };
+}
+
+// =====================================================================
 // API PÚBLICA
 // =====================================================================
 
@@ -358,11 +469,15 @@ async function obterResumoAoVivo(competicao, temporada) {
         const dados = await response.json();
         const jogos = dados.jogos || [];
 
-        // Atualizar MongoDB com jogos desta competição
+        // Atualizar MongoDB com jogos desta competição (ao vivo / hoje)
         const jogosComp = jogos.filter(j => ligaCorresponde(j.liga || j.ligaOriginal, competicao));
         if (jogosComp.length > 0) {
             await atualizarPlacaresAoVivo(competicao, temporada, jogos);
         }
+
+        // Sincronizar resultados históricos (~2 dias atrás) via Globo multi-datas
+        // Garante que jogos encerrados de dias anteriores entrem no MongoDB
+        await sincronizarMultiDatas(competicao, temporada);
 
         // Retornar resumo atualizado
         const resumo = await obterResumo(competicao, temporada);
@@ -412,6 +527,7 @@ export default {
     obterResumoAoVivo,
     atualizarPlacaresAoVivo,
     sincronizarDeJogosAoVivo,
+    sincronizarMultiDatas,
     hookAtualizarCompeticoes,
     ligaCorresponde,
     MAPA_NOMES,
@@ -424,6 +540,7 @@ export {
     obterResumoAoVivo,
     atualizarPlacaresAoVivo,
     sincronizarDeJogosAoVivo,
+    sincronizarMultiDatas,
     hookAtualizarCompeticoes,
     ligaCorresponde,
     MAPA_NOMES,


### PR DESCRIPTION
## Summary

- Mini-preview de resultados exibido nas cards do sheet Especial (Copa Nordeste, Copa Brasil, Libertadores) ao abrir a Quick Access Bar
- Jogo ao vivo: live dot pulsante vermelho + placar em tempo real
- Último resultado: placar final da última partida
- Próximo jogo: times e horário
- Cache de 60s no cliente (fire-and-forget, não bloqueia abertura do sheet)
- Cron server-side `*/5 20h-02h UTC` sincroniza status das competições no MongoDB independente de usuário ativo

## Test plan

- [ ] Abrir sheet Especial durante um jogo ao vivo — card deve mostrar live dot + placar
- [ ] Abrir sheet Especial fora de jogo — card deve mostrar último resultado ou próximo jogo
- [ ] Abrir sheet 3x em sequência — preview deve usar cache (sem re-fetch nos 60s)
- [ ] Verificar log do servidor: `[SERVER] ⚽ Cron de competições Especial agendado`
- [ ] Nenhum erro no console do browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)