### PR TITLE
fix(especiais): auditoria completa da opção Especial — segurança, rota faltante, robustez

### DIFF
--- a/public/participante/js/modules/participante-brasileirao.js
+++ b/public/participante/js/modules/participante-brasileirao.js
@@ -6,6 +6,15 @@ if (window.Log) Log.info('BRASILEIRAO-LP', 'Carregando modulo v1.0...');
 
 export async function inicializarBrasileraoParticipante() {
     try {
+        // Lazy-load do BrasileiraoTabela se ainda não foi carregado
+        if (!window.BrasileiraoTabela) {
+            try {
+                await import('../brasileirao-tabela.js');
+            } catch (importErr) {
+                if (window.Log) Log.warn('BRASILEIRAO-LP', 'Falha no lazy-load:', importErr.message);
+            }
+        }
+
         if (!window.BrasileiraoTabela) {
             const container = document.getElementById('brasileirao-classificacao-container');
             if (container) {

--- a/public/participante/js/modules/participante-copa-2026-mundo.js
+++ b/public/participante/js/modules/participante-copa-2026-mundo.js
@@ -139,7 +139,7 @@ const SIGLAS = {
     'Belgica': 'BEL', 'Egito': 'EGI', 'Ira': 'IRA', 'Nova Zelandia': 'NZL',
     'Espanha': 'ESP', 'Uruguai': 'URU', 'Arabia Saudita': 'ARS', 'Cabo Verde': 'CPV',
     'Franca': 'FRA', 'Senegal': 'SEN', 'Noruega': 'NOR',
-    'Argentina': 'ARG', 'Argelia': 'ARG', 'Austria': 'AUT', 'Jordania': 'JOR',
+    'Argentina': 'ARG', 'Argelia': 'ALG', 'Austria': 'AUT', 'Jordania': 'JOR',
     'Portugal': 'POR', 'Colombia': 'COL', 'Uzbequistao': 'UZB',
     'Inglaterra': 'ING', 'Croacia': 'CRO', 'Gana': 'GAN', 'Panama': 'PAN',
 };

--- a/public/participante/js/modules/participante-copa-brasil.js
+++ b/public/participante/js/modules/participante-copa-brasil.js
@@ -68,6 +68,27 @@ const FASES_COPA_BRASIL = [
 ];
 
 // ═══════════════════════════════════════════════════
+// UTILS
+// ═══════════════════════════════════════════════════
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function sanitizeUrl(url) {
+    if (!url) return '#';
+    const trimmed = url.trim();
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    return '#';
+}
+
+// ═══════════════════════════════════════════════════
 // INICIALIZAÇÃO
 // ═══════════════════════════════════════════════════
 
@@ -235,14 +256,14 @@ async function carregarNoticias() {
 
         if (data.success && Array.isArray(data.noticias) && data.noticias.length > 0) {
             container.innerHTML = data.noticias.map(n => {
-                const link = (n.link || '').replace(/"/g, '&quot;');
-                const titulo = (n.titulo || '').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-                const fonte = n.fonte || 'Notícia';
-                const tempo = n.tempoRelativo ? `<span class="copabr-noticia-tempo">${n.tempoRelativo}</span>` : '';
+                const link = sanitizeUrl(n.link);
+                const titulo = escapeHtml(n.titulo);
+                const fonte = escapeHtml(n.fonte || 'Notícia');
+                const tempo = n.tempoRelativo ? `<span class="copabr-noticia-tempo">${escapeHtml(n.tempoRelativo)}</span>` : '';
                 return `
-                <div class="copabr-noticia-card"
-                     onclick="window.open('${link}', '_blank')"
-                     role="link" tabindex="0">
+                <a href="${escapeHtml(link)}" target="_blank" rel="noopener"
+                   class="copabr-noticia-card"
+                   role="link" tabindex="0">
                     <div class="copabr-noticia-icon">
                         <span class="material-icons">article</span>
                     </div>
@@ -254,7 +275,7 @@ async function carregarNoticias() {
                         </div>
                     </div>
                     <span class="material-icons copabr-noticia-chevron">chevron_right</span>
-                </div>`;
+                </a>`;
             }).join('');
         } else {
             container.innerHTML = renderizarNoticiasFallback();

--- a/public/participante/js/modules/participante-copa-nordeste.js
+++ b/public/participante/js/modules/participante-copa-nordeste.js
@@ -46,6 +46,27 @@ const FASES_COPA_NORDESTE = [
     { fase: 'Grande Final',      info: '31 Mai + 7 Jun 2026',  times: 'Ida e volta',                 final: true  },
 ];
 
+// ═══════════════════════════════════════════════════
+// UTILS
+// ═══════════════════════════════════════════════════
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function sanitizeUrl(url) {
+    if (!url) return '#';
+    const trimmed = url.trim();
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    return '#';
+}
+
 // Dados dinâmicos da API (preenchidos após fetch)
 let dadosAPI = null;
 
@@ -56,6 +77,7 @@ let dadosAPI = null;
 let _pollingTimer = null;
 let _lastUpdateTs = null;
 let _isLive = false;
+let _visibilityHandler = null;
 const POLL_NORMAL_MS = 60_000;          // 60s sem jogos ao vivo
 const POLL_LIVE_MS = 30_000;            // 30s com jogos ao vivo
 const STALE_THRESHOLD_MS = 5 * 60_000;  // 5min = warning de dados desatualizados
@@ -110,6 +132,26 @@ function _iniciarPolling() {
     _pararPolling();
     const intervalo = _isLive ? POLL_LIVE_MS : POLL_NORMAL_MS;
     _pollingTimer = setInterval(_atualizarDados, intervalo);
+
+    // Parar polling quando aba fica inativa, retomar quando volta
+    if (!_visibilityHandler) {
+        _visibilityHandler = () => {
+            if (document.hidden) {
+                if (_pollingTimer) {
+                    clearInterval(_pollingTimer);
+                    _pollingTimer = null;
+                    if (window.Log) Log.debug('COPA-NORDESTE', 'Polling pausado (aba inativa)');
+                }
+            } else if (!_pollingTimer) {
+                const int = _isLive ? POLL_LIVE_MS : POLL_NORMAL_MS;
+                _pollingTimer = setInterval(_atualizarDados, int);
+                _atualizarDados(); // fetch imediato ao voltar
+                if (window.Log) Log.debug('COPA-NORDESTE', 'Polling retomado (aba ativa)');
+            }
+        };
+        document.addEventListener('visibilitychange', _visibilityHandler);
+    }
+
     if (window.Log) Log.info('COPA-NORDESTE', `Polling ativo: ${intervalo / 1000}s (${_isLive ? 'LIVE' : 'normal'})`);
 }
 
@@ -117,6 +159,10 @@ function _pararPolling() {
     if (_pollingTimer) {
         clearInterval(_pollingTimer);
         _pollingTimer = null;
+    }
+    if (_visibilityHandler) {
+        document.removeEventListener('visibilitychange', _visibilityHandler);
+        _visibilityHandler = null;
     }
 }
 
@@ -429,14 +475,14 @@ async function carregarNoticias() {
 
         if (data.success && Array.isArray(data.noticias) && data.noticias.length > 0) {
             container.innerHTML = data.noticias.map(n => {
-                const link = (n.link || '').replace(/"/g, '&quot;');
-                const titulo = (n.titulo || '').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-                const fonte = n.fonte || 'Notícia';
-                const tempo = n.tempoRelativo ? `<span class="copane-noticia-tempo">${n.tempoRelativo}</span>` : '';
+                const link = sanitizeUrl(n.link);
+                const titulo = escapeHtml(n.titulo);
+                const fonte = escapeHtml(n.fonte || 'Notícia');
+                const tempo = n.tempoRelativo ? `<span class="copane-noticia-tempo">${escapeHtml(n.tempoRelativo)}</span>` : '';
                 return `
-                <div class="copane-noticia-card"
-                     onclick="window.open('${link}', '_blank')"
-                     role="link" tabindex="0">
+                <a href="${escapeHtml(link)}" target="_blank" rel="noopener"
+                   class="copane-noticia-card"
+                   role="link" tabindex="0">
                     <div class="copane-noticia-icon">
                         <span class="material-icons">article</span>
                     </div>
@@ -448,7 +494,7 @@ async function carregarNoticias() {
                         </div>
                     </div>
                     <span class="material-icons copane-noticia-chevron">chevron_right</span>
-                </div>`;
+                </a>`;
             }).join('');
         } else {
             container.innerHTML = renderizarNoticiasFallback();

--- a/public/participante/js/modules/participante-libertadores.js
+++ b/public/participante/js/modules/participante-libertadores.js
@@ -76,6 +76,27 @@ const GRUPOS_LIBERTADORES = [
 ];
 
 // ═══════════════════════════════════════════════════
+// UTILS
+// ═══════════════════════════════════════════════════
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function sanitizeUrl(url) {
+    if (!url) return '#';
+    const trimmed = url.trim();
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    return '#';
+}
+
+// ═══════════════════════════════════════════════════
 // INICIALIZAÇÃO
 // ═══════════════════════════════════════════════════
 
@@ -163,17 +184,38 @@ function renderizarGrupos() {
     const container = document.getElementById('liberta-grupos-grid');
     if (!container) return;
 
+    // Preferir dados dinâmicos da API quando disponíveis (com classificação/pontos)
+    if (dadosAPILiberta?.grupos?.length > 0) {
+        container.innerHTML = dadosAPILiberta.grupos.map(grupo => {
+            const timesHtml = grupo.classificacao.map((t, i) => {
+                const cls = i < 2 ? 'liberta-grupo-time liberta-grupo-time--br' : 'liberta-grupo-time';
+                return `<div class="${cls}">
+                    <span class="liberta-grupo-pais">${escapeHtml(String(i + 1))}.</span>
+                    <span class="liberta-grupo-nome">${escapeHtml(t.time)}</span>
+                    <span class="liberta-grupo-pts" style="margin-left:auto;font-family:var(--app-font-mono);font-size:0.7rem;opacity:0.7">${t.pontos}pts</span>
+                </div>`;
+            }).join('');
+
+            return `<div class="liberta-grupo-card">
+                <div class="liberta-grupo-header">Grupo ${escapeHtml(grupo.nome)}</div>
+                <div class="liberta-grupo-times">${timesHtml}</div>
+            </div>`;
+        }).join('');
+        return;
+    }
+
+    // Fallback: dados estáticos do sorteio
     container.innerHTML = GRUPOS_LIBERTADORES.map(g => {
         const timesHtml = g.times.map(t => {
             const cls = t.brasileiro ? 'liberta-grupo-time liberta-grupo-time--br' : 'liberta-grupo-time';
             return `<div class="${cls}">
-                <span class="liberta-grupo-pais">${t.pais}</span>
-                <span class="liberta-grupo-nome">${t.nome}</span>
+                <span class="liberta-grupo-pais">${escapeHtml(t.pais)}</span>
+                <span class="liberta-grupo-nome">${escapeHtml(t.nome)}</span>
             </div>`;
         }).join('');
 
         return `<div class="liberta-grupo-card">
-            <div class="liberta-grupo-header">Grupo ${g.grupo}</div>
+            <div class="liberta-grupo-header">Grupo ${escapeHtml(g.grupo)}</div>
             <div class="liberta-grupo-times">${timesHtml}</div>
         </div>`;
     }).join('');
@@ -224,14 +266,14 @@ async function carregarNoticias() {
 
         if (data.success && Array.isArray(data.noticias) && data.noticias.length > 0) {
             container.innerHTML = data.noticias.map(n => {
-                const link = (n.link || '').replace(/"/g, '&quot;');
-                const titulo = (n.titulo || '').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-                const fonte = n.fonte || 'Notícia';
-                const tempo = n.tempoRelativo ? `<span class="liberta-noticia-tempo">${n.tempoRelativo}</span>` : '';
+                const link = sanitizeUrl(n.link);
+                const titulo = escapeHtml(n.titulo);
+                const fonte = escapeHtml(n.fonte || 'Notícia');
+                const tempo = n.tempoRelativo ? `<span class="liberta-noticia-tempo">${escapeHtml(n.tempoRelativo)}</span>` : '';
                 return `
-                <div class="liberta-noticia-card"
-                     onclick="window.open('${link}', '_blank')"
-                     role="link" tabindex="0">
+                <a href="${escapeHtml(link)}" target="_blank" rel="noopener"
+                   class="liberta-noticia-card"
+                   role="link" tabindex="0">
                     <div class="liberta-noticia-icon">
                         <span class="material-icons">article</span>
                     </div>
@@ -243,7 +285,7 @@ async function carregarNoticias() {
                         </div>
                     </div>
                     <span class="material-icons liberta-noticia-chevron">chevron_right</span>
-                </div>`;
+                </a>`;
             }).join('');
         } else {
             container.innerHTML = renderizarNoticiasFallback();

--- a/routes/copa-2026-noticias-routes.js
+++ b/routes/copa-2026-noticias-routes.js
@@ -6,6 +6,7 @@
 import express from 'express';
 import fetch from 'node-fetch';
 import copaConfig from '../config/copa-do-mundo-2026.js';
+import { parseRSSItems, calcularTempoRelativo } from '../utils/rss-parser.js';
 
 const router = express.Router();
 
@@ -37,78 +38,8 @@ const CATEGORIAS = {
     }
 };
 
-// ═══════════════════════════════════════════════════════
-// PARSE RSS (replicado de noticias-time-routes.js)
-// ═══════════════════════════════════════════════════════
-
-function limparTexto(texto) {
-    if (!texto) return '';
-    return texto
-        .replace(/<!\[CDATA\[/g, '')
-        .replace(/\]\]>/g, '')
-        .replace(/<[^>]+>/g, '')
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&#39;/g, "'")
-        .replace(/&apos;/g, "'")
-        .trim();
-}
-
-function extrairTag(xml, tagName) {
-    const cdataRegex = new RegExp(`<${tagName}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]></${tagName}>`, 'i');
-    const cdataMatch = xml.match(cdataRegex);
-    if (cdataMatch) return cdataMatch[1];
-
-    const regex = new RegExp(`<${tagName}[^>]*>([\\s\\S]*?)</${tagName}>`, 'i');
-    const match = xml.match(regex);
-    return match ? match[1] : '';
-}
-
-function parseRSSItems(xml) {
-    const items = [];
-    const itemRegex = /<item>([\s\S]*?)<\/item>/gi;
-    let match;
-
-    while ((match = itemRegex.exec(xml)) !== null) {
-        const itemXml = match[1];
-
-        const titulo = limparTexto(extrairTag(itemXml, 'title'));
-        const link = limparTexto(extrairTag(itemXml, 'link'));
-        const pubDate = limparTexto(extrairTag(itemXml, 'pubDate'));
-        const fonte = limparTexto(extrairTag(itemXml, 'source'));
-        const descricao = limparTexto(extrairTag(itemXml, 'description'));
-
-        if (titulo && link) {
-            items.push({
-                titulo,
-                link,
-                fonte,
-                descricao: descricao.substring(0, 200),
-                publicadoEm: pubDate ? new Date(pubDate).toISOString() : null,
-                tempoRelativo: pubDate ? calcularTempoRelativo(new Date(pubDate)) : null
-            });
-        }
-    }
-
-    return items;
-}
-
-function calcularTempoRelativo(data) {
-    const agora = new Date();
-    const diff = agora - data;
-    const minutos = Math.floor(diff / 60000);
-    const horas = Math.floor(diff / 3600000);
-    const dias = Math.floor(diff / 86400000);
-
-    if (minutos < 1) return 'agora';
-    if (minutos < 60) return `há ${minutos}min`;
-    if (horas < 24) return `há ${horas}h`;
-    if (dias === 1) return 'ontem';
-    if (dias < 7) return `há ${dias} dias`;
-    return data.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
-}
+// Funções RSS (parseRSSItems, calcularTempoRelativo)
+// importadas de ../utils/rss-parser.js
 
 // ═══════════════════════════════════════════════════════
 // BUSCA

--- a/routes/noticias-time-routes.js
+++ b/routes/noticias-time-routes.js
@@ -6,6 +6,7 @@
 import express from 'express';
 import fetch from 'node-fetch';
 import { CLUBES as CLUBES_NOTICIAS } from '../public/js/shared/clubes-data.js';
+import { limparTexto, extrairTag, parseRSSItems, calcularTempoRelativo } from '../utils/rss-parser.js';
 
 const router = express.Router();
 
@@ -17,102 +18,16 @@ const CACHE_TTL = 30 * 60 * 1000; // 30 minutos
 let cacheLibertadores = null;
 const CACHE_TTL_LIBERTA = 60 * 60 * 1000; // 1 hora
 
+// Cache separado para Copa do Brasil
+let cacheCopaBrasil = null;
+const CACHE_TTL_COPABR = 60 * 60 * 1000; // 1 hora
+
 // Cache separado para Copa do Nordeste
 let cacheCopaNordeste = null;
 const CACHE_TTL_COPANE = 60 * 60 * 1000; // 1 hora
 
-/**
- * Extrai texto limpo de um possível CDATA ou HTML
- */
-function limparTexto(texto) {
-    if (!texto) return '';
-    return texto
-        .replace(/<!\[CDATA\[/g, '')
-        .replace(/\]\]>/g, '')
-        .replace(/<[^>]+>/g, '')
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&#39;/g, "'")
-        .replace(/&apos;/g, "'")
-        .trim();
-}
-
-/**
- * Parse simples de XML RSS (sem dependência externa)
- * Extrai items do feed RSS do Google News
- */
-function parseRSSItems(xml) {
-    const items = [];
-    const itemRegex = /<item>([\s\S]*?)<\/item>/gi;
-    let match;
-
-    while ((match = itemRegex.exec(xml)) !== null) {
-        const itemXml = match[1];
-
-        const titulo = limparTexto(extrairTag(itemXml, 'title'));
-        const link = limparTexto(extrairTag(itemXml, 'link'));
-        const pubDate = limparTexto(extrairTag(itemXml, 'pubDate'));
-        const fonte = limparTexto(extrairTag(itemXml, 'source'));
-        const descricao = limparTexto(extrairTag(itemXml, 'description'));
-
-        // NOTA: Google News RSS não fornece <media:thumbnail> ou <enclosure> nos items
-        // Apenas o canal tem <image>, mas não os items individuais
-        // Alternativas futuras:
-        // 1. Scraping das URLs (complexo, lento, frágil)
-        // 2. API paga (NewsAPI, Globo Esporte API)
-        // 3. Usar escudo do clube como fallback visual (atual)
-        const imagem = null;
-
-        if (titulo && link) {
-            items.push({
-                titulo,
-                link,
-                fonte,
-                descricao: descricao.substring(0, 200),
-                publicadoEm: pubDate ? new Date(pubDate).toISOString() : null,
-                tempoRelativo: pubDate ? calcularTempoRelativo(new Date(pubDate)) : null,
-                imagem
-            });
-        }
-    }
-
-    return items;
-}
-
-/**
- * Extrai conteúdo de uma tag XML
- */
-function extrairTag(xml, tagName) {
-    // Tenta com CDATA primeiro
-    const cdataRegex = new RegExp(`<${tagName}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]></${tagName}>`, 'i');
-    const cdataMatch = xml.match(cdataRegex);
-    if (cdataMatch) return cdataMatch[1];
-
-    // Tenta sem CDATA
-    const regex = new RegExp(`<${tagName}[^>]*>([\\s\\S]*?)</${tagName}>`, 'i');
-    const match = xml.match(regex);
-    return match ? match[1] : '';
-}
-
-/**
- * Calcula tempo relativo (ex: "há 2h", "há 30min")
- */
-function calcularTempoRelativo(data) {
-    const agora = new Date();
-    const diff = agora - data;
-    const minutos = Math.floor(diff / 60000);
-    const horas = Math.floor(diff / 3600000);
-    const dias = Math.floor(diff / 86400000);
-
-    if (minutos < 1) return 'agora';
-    if (minutos < 60) return `há ${minutos}min`;
-    if (horas < 24) return `há ${horas}h`;
-    if (dias === 1) return 'ontem';
-    if (dias < 7) return `há ${dias} dias`;
-    return data.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
-}
+// Funções RSS (limparTexto, extrairTag, parseRSSItems, calcularTempoRelativo)
+// importadas de ../utils/rss-parser.js
 
 /**
  * Busca notícias do Google News RSS para um clube
@@ -225,6 +140,55 @@ async function buscarNoticiasLibertadores() {
 }
 
 /**
+ * Busca notícias da Copa do Brasil via Google News RSS
+ */
+async function buscarNoticiasCopaBrasil() {
+    // Verificar cache
+    if (cacheCopaBrasil && (Date.now() - cacheCopaBrasil.timestamp) < CACHE_TTL_COPABR) {
+        return { noticias: cacheCopaBrasil.noticias, cache: true };
+    }
+
+    try {
+        const query = encodeURIComponent('Copa do Brasil 2026');
+        const url = `https://news.google.com/rss/search?q=${query}&hl=pt-BR&gl=BR&ceid=BR:pt-419`;
+
+        console.log('[NOTICIAS] Buscando notícias da Copa do Brasil 2026...');
+
+        const response = await fetch(url, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (compatible; SuperCartolaManager/1.0)',
+                'Accept': 'application/rss+xml, application/xml, text/xml'
+            },
+            timeout: 10000
+        });
+
+        if (!response.ok) {
+            console.error(`[NOTICIAS] Erro HTTP ${response.status} ao buscar Copa do Brasil`);
+            if (cacheCopaBrasil) {
+                return { noticias: cacheCopaBrasil.noticias, cache: true, stale: true };
+            }
+            return { noticias: [], erro: 'Falha ao buscar notícias' };
+        }
+
+        const xml = await response.text();
+        const noticias = parseRSSItems(xml).slice(0, 6); // Máximo 6 notícias
+
+        console.log(`[NOTICIAS] ${noticias.length} notícias da Copa do Brasil encontradas`);
+
+        // Atualizar cache
+        cacheCopaBrasil = { noticias, timestamp: Date.now() };
+
+        return { noticias, cache: false };
+    } catch (error) {
+        console.error('[NOTICIAS] Erro ao buscar Copa do Brasil:', error.message);
+        if (cacheCopaBrasil) {
+            return { noticias: cacheCopaBrasil.noticias, cache: true, stale: true };
+        }
+        return { noticias: [], erro: error.message };
+    }
+}
+
+/**
  * Busca notícias da Copa do Nordeste via Google News RSS
  */
 async function buscarNoticiasCopaNordeste() {
@@ -326,6 +290,28 @@ router.get('/libertadores', async (req, res) => {
     } catch (error) {
         console.error('[NOTICIAS] Erro na rota libertadores:', error);
         res.status(500).json({ success: false, erro: 'Erro ao buscar notícias da Libertadores' });
+    }
+});
+
+/**
+ * GET /api/noticias/copa-brasil
+ * Retorna notícias da Copa do Brasil 2026 via Google News RSS
+ */
+router.get('/copa-brasil', async (req, res) => {
+    try {
+        const resultado = await buscarNoticiasCopaBrasil();
+
+        res.json({
+            success: true,
+            noticias: resultado.noticias,
+            total: resultado.noticias.length,
+            cache: resultado.cache || false,
+            stale: resultado.stale || false,
+            atualizadoEm: new Date().toISOString()
+        });
+    } catch (error) {
+        console.error('[NOTICIAS] Erro na rota copa-brasil:', error);
+        res.status(500).json({ success: false, erro: 'Erro ao buscar notícias da Copa do Brasil' });
     }
 });
 

--- a/utils/rss-parser.js
+++ b/utils/rss-parser.js
@@ -1,0 +1,88 @@
+// utils/rss-parser.js
+// v1.0 - Utilitários compartilhados para parse de feeds RSS (Google News)
+// Extraído de copa-2026-noticias-routes.js e noticias-time-routes.js
+
+/**
+ * Extrai texto limpo de um possível CDATA ou HTML
+ */
+export function limparTexto(texto) {
+    if (!texto) return '';
+    return texto
+        .replace(/<!\[CDATA\[/g, '')
+        .replace(/\]\]>/g, '')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&apos;/g, "'")
+        .trim();
+}
+
+/**
+ * Extrai conteúdo de uma tag XML (suporta CDATA)
+ */
+export function extrairTag(xml, tagName) {
+    const cdataRegex = new RegExp(`<${tagName}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]></${tagName}>`, 'i');
+    const cdataMatch = xml.match(cdataRegex);
+    if (cdataMatch) return cdataMatch[1];
+
+    const regex = new RegExp(`<${tagName}[^>]*>([\\s\\S]*?)</${tagName}>`, 'i');
+    const match = xml.match(regex);
+    return match ? match[1] : '';
+}
+
+/**
+ * Calcula tempo relativo (ex: "há 2h", "há 30min")
+ */
+export function calcularTempoRelativo(data) {
+    const agora = new Date();
+    const diff = agora - data;
+    const minutos = Math.floor(diff / 60000);
+    const horas = Math.floor(diff / 3600000);
+    const dias = Math.floor(diff / 86400000);
+
+    if (minutos < 1) return 'agora';
+    if (minutos < 60) return `há ${minutos}min`;
+    if (horas < 24) return `há ${horas}h`;
+    if (dias === 1) return 'ontem';
+    if (dias < 7) return `há ${dias} dias`;
+    return data.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+}
+
+/**
+ * Parse RSS XML e retorna array de notícias
+ * @param {string} xml - Conteúdo XML do feed RSS
+ * @returns {Array<{titulo, link, fonte, descricao, publicadoEm, tempoRelativo, imagem}>}
+ */
+export function parseRSSItems(xml) {
+    const items = [];
+    const itemRegex = /<item>([\s\S]*?)<\/item>/gi;
+    let match;
+
+    while ((match = itemRegex.exec(xml)) !== null) {
+        const itemXml = match[1];
+
+        const titulo = limparTexto(extrairTag(itemXml, 'title'));
+        const link = limparTexto(extrairTag(itemXml, 'link'));
+        const pubDate = limparTexto(extrairTag(itemXml, 'pubDate'));
+        const fonte = limparTexto(extrairTag(itemXml, 'source'));
+        const descricao = limparTexto(extrairTag(itemXml, 'description'));
+        const imagem = null; // Google News RSS não fornece thumbnails nos items
+
+        if (titulo && link) {
+            items.push({
+                titulo,
+                link,
+                fonte,
+                descricao: descricao.substring(0, 200),
+                publicadoEm: pubDate ? new Date(pubDate).toISOString() : null,
+                tempoRelativo: pubDate ? calcularTempoRelativo(new Date(pubDate)) : null,
+                imagem
+            });
+        }
+    }
+
+    return items;
+}


### PR DESCRIPTION
P0 (Críticos):
- Criar rota GET /api/noticias/copa-brasil que estava FALTANDO (404 em PROD)
- Corrigir XSS via onclick+links RSS nas LPs Libertadores, Copa Brasil e Copa Nordeste
  (substituir onclick="window.open('${link}')" por <a href> com escapeHtml + sanitizeUrl)
- Escapar fonte e tempoRelativo do RSS com escapeHtml() nas 3 LPs

P1 (Altos):
- Libertadores: usar dados dinâmicos da API nos grupos quando disponíveis (fallback hardcoded)
- Copa 2026: corrigir sigla Argélia duplicada ARG → ALG (sigla FIFA oficial)
- Brasileirão LP: adicionar lazy-load do BrasileiraoTabela via dynamic import

P2 (Médios):
- Extrair RSS parser duplicado para utils/rss-parser.js (compartilhado entre routes)
- Copa Nordeste: adicionar Page Visibility API ao polling (pausar em aba inativa)

https://claude.ai/code/session_015nFtEn4UN2HdDDjqrz5jND