### PR TITLE
feat: add PostToolUse auto-push hook for VPS/Docker deploy workflow

### DIFF
--- a/.claude/hooks/post-tool-use-autopush
+++ b/.claude/hooks/post-tool-use-autopush
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# PostToolUse Hook: Auto-push após git commit
+# Detecta commits feitos via Bash tool e faz push automático com retry/backoff
+
+set -euo pipefail
+
+# Ler JSON do stdin (Claude Code hook protocol)
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Só atuar em Bash tool com git commit
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+  exit 0
+fi
+
+if ! echo "$TOOL_INPUT" | grep -q "git commit"; then
+  exit 0
+fi
+
+# Verificar se o commit realmente aconteceu (exit code 0 do tool)
+TOOL_EXIT=$(echo "$INPUT" | jq -r '.tool_output.exit_code // .exit_code // "0"')
+if [[ "$TOOL_EXIT" != "0" && "$TOOL_EXIT" != "null" && "$TOOL_EXIT" != "" ]]; then
+  exit 0
+fi
+
+# Obter branch atual
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [[ -z "$BRANCH" || "$BRANCH" == "HEAD" ]]; then
+  echo "⚠️ Auto-push: não foi possível determinar a branch atual"
+  exit 0
+fi
+
+# Push com retry e backoff exponencial (4 tentativas: 2s, 4s, 8s, 16s)
+MAX_RETRIES=4
+DELAY=2
+
+for i in $(seq 1 $MAX_RETRIES); do
+  if git push -u origin "$BRANCH" 2>&1; then
+    echo "✅ Auto-push: commit enviado para origin/$BRANCH"
+    exit 0
+  fi
+
+  if [[ $i -lt $MAX_RETRIES ]]; then
+    echo "⚠️ Auto-push: tentativa $i falhou, retry em ${DELAY}s..."
+    sleep $DELAY
+    DELAY=$((DELAY * 2))
+  fi
+done
+
+echo "❌ Auto-push: falhou após $MAX_RETRIES tentativas para origin/$BRANCH"
+exit 0

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -337,6 +337,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/post-tool-use-autopush",
+            "statusMessage": "Auto-pushing após commit..."
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,15 @@ Push para `main` dispara deploy automático via `.github/workflows/main.yml`:
 Sempre verificar aba Actions no GitHub após push para confirmar sucesso do pipeline.
 Após deploy, sugerir **Ctrl+Shift+R** no navegador para limpar cache do frontend.
 
+## Git Auto-Push Workflow
+
+Hook `PostToolUse` (`.claude/hooks/post-tool-use-autopush`) faz push automático após cada `git commit` via Bash tool.
+
+- **NÃO faça `git push` manual** — o hook cuida automaticamente
+- Deploy é via **GitHub Actions → VPS Docker** (não Vercel). Push para `main` = deploy automático
+- Retry com backoff exponencial (2s/4s/8s/16s, até 4 tentativas) em falha de rede
+- O hook só ativa quando `tool_name == Bash` e o comando contém `git commit`
+
 ## Critical Rules
 
 1. NEVER remove `gemini_audit.py`


### PR DESCRIPTION
- New hook .claude/hooks/post-tool-use-autopush: detects git commits
  via Bash tool and auto-pushes with retry/exponential backoff
- Registered hook in settings.local.json as PostToolUse
- Added Git Auto-Push Workflow section to CLAUDE.md

https://claude.ai/code/session_01Ws23udsPGABT5b827eEq5G