### PR TITLE
fix(escalacao-ia): botão gerar re-executável, nomes variam com patrimônio, GatoMestre real

### DIFF
--- a/public/js/admin/modules/admin-escalacao-ia.js
+++ b/public/js/admin/modules/admin-escalacao-ia.js
@@ -14,7 +14,7 @@
     const API_BASE = '/api/admin/escalacao-ia';
     let cenarioAtual = null;
     let dadosCompletos = null;
-    let patrimonioAlteradoManualmente = false;
+    let _gerando = false; // Guard contra re-entrância
 
     // =====================================================================
     // HELPERS MODO PROFESSOR
@@ -67,10 +67,6 @@
         console.log('[ESCALACAO-IA] Inicializando módulo v2.0...');
         configurarTabs();
         configurarToggleProfessor();
-        // Rastrear alteração manual do patrimônio pelo usuário
-        document.getElementById('eia-patrimonio')?.addEventListener('change', () => {
-            patrimonioAlteradoManualmente = true;
-        });
         await carregarStatusFontes();
         await tentarAutoLoad();
     }
@@ -199,9 +195,13 @@
     // =====================================================================
 
     async function gerar() {
-        // Se o usuário não alterou manualmente, envia vazio → backend busca da conta real do admin
+        // Guard contra re-entrância (double-click)
+        if (_gerando) return;
+        _gerando = true;
+
+        // Sempre enviar o valor atual do input patrimônio ao backend
         const patrimonioEl = document.getElementById('eia-patrimonio');
-        const patrimonio = patrimonioAlteradoManualmente ? (patrimonioEl?.value || '') : '';
+        const patrimonio = patrimonioEl?.value || '';
         const esquemaId = document.getElementById('eia-esquema')?.value || 3;
 
         mostrarLoading(true);
@@ -229,10 +229,9 @@
 
             dadosCompletos = data;
 
-            // Atualizar input com patrimônio real retornado pelo backend
-            if (data.patrimonio && patrimonioEl) {
+            // Atualizar input com patrimônio real retornado pelo backend (só se vazio)
+            if (data.patrimonio && patrimonioEl && !patrimonioEl.value) {
                 patrimonioEl.value = data.patrimonio;
-                patrimonioAlteradoManualmente = false;
             }
 
             // Selecionar modo sugerido
@@ -251,6 +250,7 @@
             console.error('[ESCALACAO-IA] Erro ao gerar:', error);
             mostrarErro(error.message);
         } finally {
+            _gerando = false;
             mostrarLoading(false);
         }
     }
@@ -270,7 +270,7 @@
         if (!confirmar) return;
 
         const patrimonioEl = document.getElementById('eia-patrimonio');
-        const patrimonio = patrimonioAlteradoManualmente ? (patrimonioEl?.value || '') : '';
+        const patrimonio = patrimonioEl?.value || '';
         const esquemaId = document.getElementById('eia-esquema')?.value || 3;
 
         mostrarLoading(true);
@@ -294,11 +294,9 @@
 
             dadosCompletos = data;
 
-            // Atualizar input com patrimônio real retornado pelo backend
-            const patrimonioElR = document.getElementById('eia-patrimonio');
-            if (data.patrimonio && patrimonioElR) {
-                patrimonioElR.value = data.patrimonio;
-                patrimonioAlteradoManualmente = false;
+            // Atualizar input com patrimônio real retornado pelo backend (só se vazio)
+            if (data.patrimonio && patrimonioEl && !patrimonioEl.value) {
+                patrimonioEl.value = data.patrimonio;
             }
 
             const modoSugerido = data.modoSugerido?.modo || 'equilibrado';

--- a/services/escalacaoIA/aiSynthesizer.js
+++ b/services/escalacaoIA/aiSynthesizer.js
@@ -106,7 +106,8 @@ function gerarJustificativaLocal(jogador) {
  */
 async function gerarJustificativas(cenario, contexto = {}) {
     const modoProfessor = contexto.modoProfessor || false;
-    const cacheKey = `synth_${cenario.modo}_r${contexto.rodada}${modoProfessor ? '_prof' : ''}`;
+    const patrimonioKey = contexto.patrimonio ? `_p${Math.round(contexto.patrimonio)}` : '';
+    const cacheKey = `synth_${cenario.modo}_r${contexto.rodada}${patrimonioKey}${modoProfessor ? '_prof' : ''}`;
     const cached = cache.get(cacheKey);
     if (cached) return cached;
 

--- a/services/escalacaoIA/dataAggregator.js
+++ b/services/escalacaoIA/dataAggregator.js
@@ -87,38 +87,52 @@ async function buscarGatoMestrePremium() {
             return null;
         }
 
-        // Tentar multiplos endpoints premium em paralelo
-        const [sugestoes, destaques, escalacao] = await Promise.allSettled([
-            systemTokenService.fazerRequisicaoAutenticada('/auth/dicas/sugestoes'),
-            systemTokenService.fazerRequisicaoAutenticada('/auth/mercado/destaques'),
-            systemTokenService.fazerRequisicaoAutenticada('/auth/escalacao/sugestao'),
-        ]);
+        // Usar endpoint REAL confirmado: /auth/time (retorna time do admin autenticado)
+        // Endpoints especulativos (/auth/dicas/sugestoes, /auth/mercado/destaques,
+        // /auth/escalacao/sugestao) NÃO existem na API oficial do Cartola
+        const authTimeResult = await systemTokenService.fazerRequisicaoAutenticada('/auth/time');
 
-        const sugestoesRaw = sugestoes.status === 'fulfilled' && sugestoes.value?.success ? sugestoes.value.data : null;
-        const destaquesRaw = destaques.status === 'fulfilled' && destaques.value?.success ? destaques.value.data : null;
-        const escalacaoRaw = escalacao.status === 'fulfilled' && escalacao.value?.success ? escalacao.value.data : null;
+        if (!authTimeResult.success || !authTimeResult.data) {
+            console.log(`${LOG_PREFIX} GatoMestre Premium: /auth/time falhou`);
+            return null;
+        }
 
-        // Normalizar sugestoes em mapa indexado por atleta_id
-        // A API pode retornar array, objeto com .atletas, ou mapa direto
-        const sugestoesMap = normalizarSugestoesGatoMestre(sugestoesRaw, destaquesRaw, escalacaoRaw);
+        const timeData = authTimeResult.data;
+        const timeInfo = timeData.time || timeData;
+
+        // Extrair dados úteis do time autenticado
+        const patrimonioReal = timeInfo.patrimonio || 0;
+        const esquemaIdReal = timeInfo.esquema_id || 3;
+
+        // Jogadores escalados pelo admin = sinal de preferência pessoal
+        // Se o admin escalou esses jogadores no Cartola real, eles recebem boost
+        const atletasEscalados = timeInfo.atletas || [];
+        const sugestoesMap = {};
+
+        for (const atleta of atletasEscalados) {
+            const id = atleta.atleta_id || atleta.id;
+            if (!id) continue;
+            sugestoesMap[id] = {
+                score: atleta.pontos_num || atleta.media_num || 0,
+                recomendado: true,
+                naEscalacaoOficial: true,
+                fonte: 'gatomestre-time-admin',
+            };
+        }
 
         const resultado = {
-            sugestoes: sugestoesRaw,
-            sugestoesMap, // Mapa indexado por atleta_id para lookup rápido
-            destaques: destaquesRaw,
-            escalacaoOficial: escalacaoRaw,
-            disponivel: false,
+            sugestoes: null,
+            sugestoesMap,
+            destaques: null,
+            escalacaoOficial: atletasEscalados,
+            patrimonioReal,
+            esquemaIdReal,
+            disponivel: true,
         };
 
-        resultado.disponivel = !!(sugestoesRaw || destaquesRaw || escalacaoRaw);
-
-        if (resultado.disponivel) {
-            cache.set(cacheKey, resultado);
-            const totalMapeados = Object.keys(sugestoesMap).length;
-            console.log(`${LOG_PREFIX} GatoMestre Premium: dados obtidos (${totalMapeados} atletas mapeados)`);
-        } else {
-            console.log(`${LOG_PREFIX} GatoMestre Premium: nenhum endpoint retornou dados`);
-        }
+        cache.set(cacheKey, resultado);
+        const totalMapeados = Object.keys(sugestoesMap).length;
+        console.log(`${LOG_PREFIX} GatoMestre Premium: dados reais obtidos (patrimonio=C$${patrimonioReal}, ${totalMapeados} jogadores escalados)`);
 
         return resultado;
     } catch (error) {
@@ -245,9 +259,9 @@ function normalizarSugestoesGatoMestre(sugestoesRaw, destaquesRaw, escalacaoRaw)
  * @returns {Object} Dados agregados normalizados
  */
 async function agregarDados(options = {}) {
-    const cacheKey = 'agg_completo';
-    const cached = cache.get(cacheKey);
-    if (cached) return cached;
+    // Sem cache no nível do aggregator — cada sub-fonte tem seu próprio cache
+    // (cartola API 15min, gatomestre 15min, cedidos 10min, etc.)
+    // Isso permite que cada clique em "Gerar" recalcule o ranking com patrimônio diferente
 
     console.log(`${LOG_PREFIX} Iniciando agregacao multi-fonte...`);
     const inicio = Date.now();
@@ -460,8 +474,6 @@ async function agregarDados(options = {}) {
         tempoMs: Date.now() - inicio,
         geradoEm: new Date().toISOString(),
     };
-
-    cache.set(cacheKey, resultado);
 
     // Salvar snapshot no MongoDB
     await salvarSnapshot(resultado);

--- a/services/escalacaoIA/scoringEngine.js
+++ b/services/escalacaoIA/scoringEngine.js
@@ -192,10 +192,30 @@ function calcularScoreFinal(atleta, modo = MODOS.EQUILIBRADO) {
         // Fontes inativas simplesmente não contribuem — peso redistribuído automaticamente
     }
 
-    // Aplicar fator valorizacao (para modo VALORIZAR, priorizar baratos com potencial)
-    if (pesoValorizacao > 0 && atleta.variacao > 0) {
-        const fatorValorizacao = 1 + (atleta.variacao / 10) * (pesoValorizacao / 100);
-        scorePonderado *= fatorValorizacao;
+    // Aplicar fator de modo de estratégia (diferenciação agressiva entre MITAR e VALORIZAR)
+    if (pesoValorizacao > 0) {
+        const preco = atleta.preco || 1;
+        const media = atleta.media || 0;
+
+        // Custo-benefício: jogadores baratos com boa média recebem boost significativo
+        const custoBeneficio = media / Math.max(preco, 1);
+        // custoBeneficio típico: 0.5-3.0. Normalizar para fator multiplicador
+        // pesoValorizacao=100 (VALORIZAR): fator pode chegar a 1.6x para CB alto
+        // pesoValorizacao=50 (EQUILIBRADO): fator moderado ~1.2x
+        const fatorCB = 1 + (Math.min(custoBeneficio, 3) / 3) * (pesoValorizacao / 100) * 0.6;
+        scorePonderado *= fatorCB;
+
+        // Bonus adicional por variação positiva (jogador em alta)
+        if (atleta.variacao > 0) {
+            const fatorValorizacao = 1 + (atleta.variacao / 5) * (pesoValorizacao / 100) * 0.3;
+            scorePonderado *= fatorValorizacao;
+        }
+
+        // Penalidade para jogadores caros no modo VALORIZAR (desincentiva gastar muito)
+        if (pesoValorizacao >= 80 && preco > 15) {
+            const penalizaCaro = 1 - ((preco - 15) / 30) * 0.2; // Até -20% para preco=45+
+            scorePonderado *= Math.max(penalizaCaro, 0.8);
+        }
     }
 
     // Penalidades


### PR DESCRIPTION
## Summary

Correções de usabilidade da Escalação IA: botão travava, nomes não mudavam, GatoMestre Premium não funcionava.

### 4 problemas corrigidos:

- **Botão "Gerar" travava após 1 clique** — adicionado guard `_gerando` contra re-entrância + patrimônio sempre enviado ao backend (removido flag `patrimonioAlteradoManualmente` que bloqueava reenvio)
- **Nomes 95% iguais ao mudar patrimônio** — removido cache estático `agg_completo` (TTL 15min) que retornava mesmos dados independente do patrimônio. Sub-caches das fontes externas já evitam chamadas duplicadas. Cache do synthesizer agora inclui patrimônio na key.
- **Modos MITAR/VALORIZAR geravam mesma escalação** — VALORIZAR agora aplica custo-benefício agressivo (`media/preco`) + penalidade para jogadores caros (>C$15). MITAR mantém foco em media pura. Escalações visivelmente diferentes.
- **GatoMestre Premium não influenciava** — substituídos 3 endpoints especulativos que retornavam 404 (`/auth/dicas/sugestoes`, `/auth/mercado/destaques`, `/auth/escalacao/sugestao`) por `/auth/time` (endpoint real confirmado). Extrai patrimônio real e jogadores escalados pelo admin como sinal de preferência.

### Arquivos modificados (4):
- `public/js/admin/modules/admin-escalacao-ia.js` — guard re-entrância, patrimônio sempre enviado
- `services/escalacaoIA/dataAggregator.js` — removido cache `agg_completo`, GatoMestre via `/auth/time`
- `services/escalacaoIA/scoringEngine.js` — custo-benefício agressivo no VALORIZAR
- `services/escalacaoIA/aiSynthesizer.js` — patrimônio no cache key

## Test plan

- [ ] Clicar "Gerar" 3x seguidas — deve funcionar todas as vezes
- [ ] Mudar patrimônio C$80 → C$200 → C$400 — nomes devem mudar significativamente
- [ ] Comparar MITAR vs VALORIZAR — escalações devem ser visivelmente diferentes
- [ ] Com GatoMestre conectado, verificar log `[DATA-AGGREGATOR] GatoMestre Premium: dados reais obtidos` no servidor
- [ ] Verificar que botão re-habilita após erro de rede

https://claude.ai/code/session_01KQTBGwAeJ5WVtawn6bSiDa