### PR TITLE
feat: substituir FAB fogo por FAB Big Cartola IA

### DIFF
--- a/public/participante/css/whats-happening.css
+++ b/public/participante/css/whats-happening.css
@@ -1,10 +1,10 @@
 /**
  * BIG CARTOLA IA - FAB Widget CSS
  * ================================
- * FAB flutuante "Em breve Big Cartola IA"
+ * FAB flutuante discreto "Em breve Big Cartola IA"
  * Tema: roxo/índigo (IA) usando tokens do design system
  *
- * v4.0 - Substituiu widget "O que tá rolando?" (fire states)
+ * v5.0 - Simplificado: sem glow, sem anel, sem breathing
  */
 
 /* ========================================
@@ -13,10 +13,6 @@
 :root {
     --wh-ai-primary: var(--app-purple);           /* #8b5cf6 */
     --wh-ai-secondary: var(--app-indigo);          /* #6366f1 */
-    --wh-ai-glow: rgba(139, 92, 246, 0.6);
-    --wh-ai-glow-soft: rgba(139, 92, 246, 0.4);
-    --wh-ai-glow-subtle: rgba(139, 92, 246, 0.2);
-    --wh-ai-glow-faint: rgba(139, 92, 246, 0.08);
 }
 
 /* ========================================
@@ -26,25 +22,19 @@
     position: fixed;
     bottom: 80px;
     right: 16px;
-    width: 60px;
-    height: 60px;
+    width: 56px;
+    height: 56px;
     border-radius: 50%;
-    background: linear-gradient(135deg, var(--wh-ai-primary) 0%, var(--wh-ai-secondary) 100%);
-    background-size: 200% 200%;
-    border: 3px solid rgba(255, 255, 255, 0.25);
-    box-shadow:
-        0 4px 20px var(--wh-ai-glow),
-        0 0 40px var(--wh-ai-glow-subtle),
-        inset 0 -2px 10px rgba(0, 0, 0, 0.2);
+    background: linear-gradient(135deg, var(--wh-ai-primary), var(--wh-ai-secondary));
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     cursor: grab;
     z-index: var(--app-z-fab);
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-                box-shadow 0.3s ease,
-                border-color 0.3s ease;
-    animation: wh-fab-entrance 0.6s ease-out, wh-ai-gradient 4s ease infinite, wh-ai-breathe 3s ease-in-out infinite;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    animation: wh-fab-entrance 0.4s ease-out;
     touch-action: none;
     user-select: none;
     -webkit-user-select: none;
@@ -53,49 +43,19 @@
 /* Estado arrastando */
 .wh-fab.dragging {
     cursor: grabbing;
-    transform: scale(1.1);
-    box-shadow:
-        0 8px 30px var(--wh-ai-glow),
-        0 0 60px var(--wh-ai-glow-soft);
-    animation: none;
+    transform: scale(1.08);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
     opacity: 0.9;
 }
 
 /* Animação de "solto" quando para de arrastar */
 .wh-fab.just-dropped {
-    animation: wh-drop-bounce 0.4s ease-out;
-}
-
-/* Anel externo */
-.wh-fab::before {
-    content: '';
-    position: absolute;
-    inset: -4px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, var(--wh-ai-primary), var(--wh-ai-secondary), var(--wh-ai-primary));
-    background-size: 300% 300%;
-    animation: wh-ai-ring 3s linear infinite;
-    z-index: -1;
-    opacity: 0.6;
-}
-
-/* Glow externo */
-.wh-fab::after {
-    content: '';
-    position: absolute;
-    inset: -8px;
-    border-radius: 50%;
-    background: radial-gradient(circle, var(--wh-ai-glow-subtle) 0%, transparent 70%);
-    animation: wh-ai-glow-pulse 2s ease-in-out infinite;
-    z-index: -2;
+    animation: wh-drop-bounce 0.3s ease-out;
 }
 
 .wh-fab:hover {
-    transform: scale(1.15) rotate(-5deg);
-    box-shadow:
-        0 8px 30px var(--wh-ai-glow),
-        0 0 60px var(--wh-ai-glow-soft);
-    border-color: rgba(255, 255, 255, 0.4);
+    transform: scale(1.08);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .wh-fab:active {
@@ -104,10 +64,9 @@
 
 /* Ícone do FAB */
 .wh-fab-icon {
-    font-size: 32px;
+    font-size: 28px;
     color: var(--app-text-primary);
-    transition: transform 0.3s ease;
-    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.2));
 }
 
 /* ========================================
@@ -117,9 +76,9 @@
     position: fixed;
     bottom: 150px;
     left: 50%;
-    transform: translateX(-50%) translateY(20px);
+    transform: translateX(-50%) translateY(10px);
     background: var(--app-toast-bg, #1e293b);
-    border: 1px solid var(--wh-ai-glow-subtle);
+    border: 1px solid rgba(139, 92, 246, 0.25);
     border-radius: 12px;
     padding: 12px 20px;
     display: flex;
@@ -127,10 +86,8 @@
     gap: 10px;
     z-index: calc(var(--app-z-fab) + 1);
     opacity: 0;
-    transition: opacity 0.3s ease, transform 0.3s ease;
-    box-shadow:
-        0 4px 20px rgba(0, 0, 0, 0.4),
-        0 0 20px var(--wh-ai-glow-faint);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
     pointer-events: none;
 }
 
@@ -140,9 +97,8 @@
 }
 
 .wh-ai-toast-icon {
-    font-size: 24px;
+    font-size: 22px;
     color: var(--wh-ai-primary);
-    animation: wh-ai-icon-pulse 1.5s ease-in-out infinite;
 }
 
 .wh-ai-toast-text {
@@ -162,38 +118,11 @@
    ======================================== */
 @keyframes wh-fab-entrance {
     0% { transform: scale(0); opacity: 0; }
-    50% { transform: scale(1.2); }
     100% { transform: scale(1); opacity: 1; }
 }
 
-@keyframes wh-ai-gradient {
-    0%, 100% { background-position: 0% 50%; }
-    50% { background-position: 100% 50%; }
-}
-
-@keyframes wh-ai-breathe {
-    0%, 100% { transform: scale(1); }
-    50% { transform: scale(1.05); }
-}
-
-@keyframes wh-ai-ring {
-    0% { background-position: 0% 50%; }
-    100% { background-position: 300% 50%; }
-}
-
-@keyframes wh-ai-glow-pulse {
-    0%, 100% { opacity: 0.5; transform: scale(1); }
-    50% { opacity: 1; transform: scale(1.1); }
-}
-
-@keyframes wh-ai-icon-pulse {
-    0%, 100% { opacity: 0.8; }
-    50% { opacity: 1; }
-}
-
 @keyframes wh-drop-bounce {
-    0% { transform: scale(1.1); }
-    40% { transform: scale(0.95); }
-    70% { transform: scale(1.02); }
+    0% { transform: scale(1.08); }
+    50% { transform: scale(0.96); }
     100% { transform: scale(1); }
 }

--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -116,7 +116,7 @@
         <link rel="stylesheet" href="css/module-lp.css?v=20260322" />
 
         <!-- ✅ FAB "Big Cartola IA" -->
-        <link rel="stylesheet" href="css/whats-happening.css?v=5" />
+        <link rel="stylesheet" href="css/whats-happening.css?v=6" />
 
         <!-- ✅ Widget "Raio-X da Rodada" -->
         <link rel="stylesheet" href="css/round-xray-widget.css?v=20260322" />

--- a/public/participante/js/widgets/whats-happening-widget.js
+++ b/public/participante/js/widgets/whats-happening-widget.js
@@ -147,7 +147,7 @@ function showAiToast() {
     toast.id = "wh-ai-toast";
     toast.className = "wh-ai-toast";
     toast.innerHTML = `
-        <span class="material-icons wh-ai-toast-icon">smart_toy</span>
+        <span class="material-icons wh-ai-toast-icon">auto_awesome</span>
         <span class="wh-ai-toast-text">Em breve <strong>Big Cartola IA</strong></span>
     `;
     document.body.appendChild(toast);
@@ -180,7 +180,7 @@ function createWidgetElements() {
     fab.id = "wh-fab";
     fab.className = "wh-fab wh-fab--ai";
     fab.innerHTML = `
-        <span class="material-icons wh-fab-icon">smart_toy</span>
+        <span class="material-icons wh-fab-icon">auto_awesome</span>
     `;
 
     // Aplicar posição salva


### PR DESCRIPTION
## Summary
- Remove widget "O que tá rolando?" (foguinho com state machine LIVE/WAITING/COOLING/FINISHED, painel de disputas, polling de APIs)
- Substitui por FAB simples com ícone de IA (`smart_toy`) em tema roxo/índigo
- Click mostra toast "Em breve Big Cartola IA"
- Mantém drag & drop e posição salva no localStorage

## Arquivos modificados
- `whats-happening-widget.js` — reescrito (state machine → FAB simples + toast)
- `whats-happening.css` — reescrito (tema fogo → tema IA com tokens `--app-purple`/`--app-indigo`)
- `participante-navigation.js` — simplificado (removido check de módulo)
- `index.html` — cache bust CSS v4 → v5

## Test plan
- [ ] Abrir app participante no browser
- [ ] Verificar FAB roxo com ícone de robô (smart_toy)
- [ ] Clicar no FAB → toast "Em breve Big Cartola IA" aparece
- [ ] Arrastar FAB → posição salva e restaurada ao recarregar
- [ ] Ctrl+Shift+R após deploy para limpar cache

https://claude.ai/code/session_01VDaVT5mhuzpFQGgzJSnYYq