### PR TITLE
fix: resolve infinite loading spinner on Brasileirão Série A landing page

### DIFF
--- a/public/participante/js/brasileirao-tabela.js
+++ b/public/participante/js/brasileirao-tabela.js
@@ -7,6 +7,24 @@
 
 // RODADA_FINAL_CAMPEONATO disponível via participante-cache-manager.js (global)
 
+const _BRASILEIRAO_FETCH_TIMEOUT = 10000; // 10s
+
+async function _fetchComTimeout(url, options = {}, timeout = _BRASILEIRAO_FETCH_TIMEOUT) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+    try {
+        const response = await fetch(url, { ...options, signal: controller.signal });
+        clearTimeout(timeoutId);
+        return response;
+    } catch (error) {
+        clearTimeout(timeoutId);
+        if (error.name === 'AbortError') {
+            throw new Error(`Timeout após ${timeout}ms: ${url}`);
+        }
+        throw error;
+    }
+}
+
 const BrasileiraoTabela = {
     _containerId: null,
     _temporada: null,
@@ -39,7 +57,7 @@ const BrasileiraoTabela = {
                 ? `/api/brasileirao/ao-vivo/${this._temporada}`
                 : `/api/brasileirao/resumo/${this._temporada}`;
 
-            const response = await fetch(endpoint);
+            const response = await _fetchComTimeout(endpoint);
             const data = await response.json();
 
             if (!data.success) {
@@ -67,7 +85,7 @@ const BrasileiraoTabela = {
      */
     async _verificarMatchdayStatus() {
         try {
-            const response = await fetch('/api/matchday/status');
+            const response = await _fetchComTimeout('/api/matchday/status');
             const data = await response.json();
 
             if (data.success) {
@@ -302,7 +320,7 @@ const BrasileiraoTabela = {
 
         try {
             const temporada = this._temporada || new Date().getFullYear();
-            const response = await fetch(`/api/brasileirao/classificacao/${temporada}`);
+            const response = await _fetchComTimeout(`/api/brasileirao/classificacao/${temporada}`);
             const data = await response.json();
 
             if (!data.success || !data.classificacao || data.classificacao.length === 0) {
@@ -323,6 +341,16 @@ const BrasileiraoTabela = {
             container.innerHTML = this._renderClassificacao(data.classificacao, data.rodada_atual, meuClubeId);
         } catch (err) {
             console.warn('[BRASILEIRAO-TABELA] Erro classificação:', err);
+            container.innerHTML = `
+                <div class="brasileirao-class-vazio">
+                    <span class="material-icons" style="color: var(--app-danger);">error_outline</span>
+                    <p>Erro ao carregar classificação</p>
+                    <button onclick="window.BrasileiraoTabela && window.BrasileiraoTabela.renderizarClassificacao('${containerId}')"
+                            style="margin-top: 8px; padding: 4px 12px; font-size: 12px; border: 1px solid var(--app-border); border-radius: 6px; background: transparent; color: var(--app-text-dim); cursor: pointer;">
+                        <span class="material-icons" style="font-size: 14px; vertical-align: middle;">refresh</span> Tentar novamente
+                    </button>
+                </div>
+            `;
         }
     },
 
@@ -553,7 +581,7 @@ const BrasileiraoTabela = {
     async _fetchTabelaCompleta(overlay) {
         const contentEl = overlay.querySelector('#brasileirao-lp-content');
         try {
-            const response = await fetch(`/api/brasileirao/completo/${this._temporada}`);
+            const response = await _fetchComTimeout(`/api/brasileirao/completo/${this._temporada}`);
             const data = await response.json();
 
             if (data.success) {
@@ -777,7 +805,7 @@ const BrasileiraoTabela = {
         this._autoRefreshTimer = setInterval(async () => {
             try {
                 // Sempre usar /ao-vivo durante refresh (dados frescos com placares)
-                const response = await fetch(`/api/brasileirao/ao-vivo/${this._temporada}`);
+                const response = await _fetchComTimeout(`/api/brasileirao/ao-vivo/${this._temporada}`);
                 const data = await response.json();
 
                 if (data.success) {

--- a/public/participante/js/modules/participante-brasileirao.js
+++ b/public/participante/js/modules/participante-brasileirao.js
@@ -46,6 +46,27 @@ export async function inicializarBrasileraoParticipante() {
         _statusInterval = setInterval(_atualizarStatus, 60000);
     } catch (err) {
         if (window.Log) Log.warn('BRASILEIRAO-LP', 'Erro ao renderizar:', err);
+
+        // Limpar spinners que ficaram presos
+        const classContainer = document.getElementById('brasileirao-classificacao-container');
+        if (classContainer && classContainer.querySelector('[role="status"]')) {
+            classContainer.innerHTML = `
+                <div class="text-center py-6">
+                    <span class="material-icons text-2xl" style="color: var(--app-danger);">error_outline</span>
+                    <p class="text-gray-500 mt-2 text-xs">Erro ao carregar dados</p>
+                </div>
+            `;
+        }
+
+        const tabelaContainer = document.getElementById('brasileirao-tabela-container');
+        if (tabelaContainer && !tabelaContainer.innerHTML.trim()) {
+            tabelaContainer.innerHTML = `
+                <div class="text-center py-6">
+                    <span class="material-icons text-2xl" style="color: var(--app-danger);">error_outline</span>
+                    <p class="text-gray-500 mt-2 text-xs">Erro ao carregar jogos</p>
+                </div>
+            `;
+        }
     }
 }
 


### PR DESCRIPTION
- Add _fetchComTimeout helper with 10s AbortController timeout to all fetch calls
- Fix renderizarClassificacao() catch block to update DOM with error state + retry button
- Fix inicializarBrasileraoParticipante() catch block to clear spinner on error

The spinner stayed forever because catch blocks only logged to console without
updating the DOM. Now all error paths show proper error messages to the user.

https://claude.ai/code/session_013RnEcFvRn2KfGwLnLmW28M