### PR TITLE
fix(brasileirao-lp): corrigir loading infinito na opção Especial

### DIFF
--- a/.claude/LESSONS.md
+++ b/.claude/LESSONS.md
@@ -39,6 +39,7 @@
 | 2026-03-16 | PROCESSO | Phosphor Icons bloqueado por CSP em PROD — `unpkg.com` estava em `style-src` e `connect-src` mas NÃO em `font-src`. 18 font requests bloqueados por page load causando lentidão extrema reportada por usuários. | **Ao adicionar dependência CDN externa, atualizar TODAS as diretivas CSP relevantes** (script/style/font/connect). Libs de ícones carregam sub-recursos (fontes) de domínios diferentes do script principal. Testar com DevTools Console aberto em PROD. Comentários inline adicionados ao CSP documentando cada domínio. | Sim — comentários de blindagem no CSP |
 | 2026-03-15 | PROCESSO | App do participante fazia 7-9 fetches a cada acesso (cold/warm start). 3 sistemas de cache sobrepostos (ParticipanteCacheDB, SuperCartolaOffline, ParticipanteCacheManager) causavam inconsistências. Dados imutáveis (rodadas consolidadas) eram re-buscados desnecessariamente. | **Super Cache Inteligente implementado.** Backend envia `cacheHint` (ttl, imutavel, versao) em todo response. Frontend unificado (L1 memória + L2 IndexedDB) com SWR inteligente. Imutáveis NUNCA revalidam. Warm start: 0-3 requests (vs 7-9). Navegação SPA: 0 re-fetches. Referência: `docs/superpowers/specs/2026-03-15-super-cache-inteligente-design.md` | Não |
 | 2026-04-02 | FRONTEND | Chip "Big Cartola IA" usava `alert('Em breve Big Cartola IA')` — dialog nativo do browser, visual amador, fora do design system dark mode. | **NUNCA usar `alert()` nativo do browser.** Usar `window.ErrorToast.show(msg, { tipo: 'info', duracao: 2500 })` (app participante) ou `mostrarAguarde(nomeCard)` para features bloqueadas. `alert()` quebra a experiência dark mode e parece amador. | Sim — regra "NUNCA alert()" em Coding Standards |
+| 2026-04-02 | FRONTEND | LP "Brasileirão" (menu Especial) ficava em loading infinito. Módulo delegava 100% ao `BrasileiraoTabela` (componente da HOME) que dependia de cadeia de APIs externas (ESPN+Cartola+matchday) sem fallback. Os outros 3 módulos Especial (Libertadores, Copa-BR, Copa-NE) funcionam porque têm dados estáticos hardcoded. Também: `TIMES_ESPN_MAP` com times errados (Chapecoense, Coritiba, Remo) e faltando reais (Fortaleza, Sport, Juventude). E `node-fetch` v3 ignora silenciosamente opção `timeout`. | **Módulos de LP tipo "Especial" DEVEM ter dados estáticos de fallback** — NUNCA depender 100% de API externa. Padrão provado: fetch API → se falha → renderizar fallback estático → SEMPRE mostra algo. Também: `node-fetch` v3 não suporta `timeout` — usar `AbortController` com `setTimeout`. Também: mapas de times (`TIMES_ESPN_MAP`) devem ser atualizados a cada temporada. | Não |
 
 ### PROCESSO — CSP desatualizada ao adicionar dependência externa (1 ocorrência)
 - Phosphor Icons adicionado via `cdn.jsdelivr.net` (script) + `unpkg.com` (fonts), mas `font-src` não incluía `unpkg.com` (2026-03-16)
@@ -82,6 +83,15 @@
 
 ---
 
+### FRONTEND — Módulo sem fallback estático = loading infinito (1 ocorrência, padrão preventivo)
+- LP Brasileirão: 100% dependente de APIs externas, sem dados estáticos. Os 3 módulos irmãos (Libertadores, Copa-BR, Copa-NE) tinham fallback e funcionavam. (2026-04-02)
+
+**Padrão:** Módulos que renderizam conteúdo externo (competições, tabelas, classificações) ficam em loading infinito quando a cadeia de APIs falha. Fallback estático é obrigatório.
+
+**Regra:** Todo módulo LP em "Especial" DEVE ter: (1) dados estáticos hardcoded (times, fases, datas), (2) fetch com timeout defensivo (AbortController, 8s), (3) se API falha → renderizar fallback → NUNCA spinner infinito. Ao criar novo módulo Especial, copiar padrão de `participante-copa-nordeste.js`.
+
+---
+
 ### FRONTEND — `escapeHtml` não definida localmente (3 ocorrências)
 - `top10.js` (2026-02-28)
 - `capitao-luxo.js` (2026-02-28)
@@ -112,3 +122,4 @@ function escapeHtml(str) {
 | 2026-03-15 | Skill antes de ação — SEMPRE. Bug→systematic-debugging, CSS→anti-frank, Visual→frontend-design | Seção "Skills & Commands" | 3 ocorrências de skill ignorada (padrão recorrente PROCESSO) |
 | 2026-03-16 | CSP: ao adicionar CDN externo, atualizar TODAS as diretivas (script/style/font/connect) | Comentários inline em `middleware/security.js` | Phosphor Icons bloqueado em font-src, 18 requests falhando |
 | 2026-04-02 | NUNCA usar `alert()` nativo — usar `ErrorToast.show()` ou toast do design system | Seção "Coding Standards" | Chip "Big Cartola IA" com alert() ficou visual amador, fora do dark mode |
+| 2026-04-02 | Módulos LP Especial DEVEM ter fallback estático; `node-fetch` v3 não suporta `timeout`; `TIMES_ESPN_MAP` atualizar por temporada | Padrão Recorrente FRONTEND (preventivo) | LP Brasileirão loading infinito — sem fallback, ESPN map errado, timeout ignorado |

--- a/public/participante/css/brasileirao-lp.css
+++ b/public/participante/css/brasileirao-lp.css
@@ -148,3 +148,169 @@
     font-family: var(--app-font-base, 'Inter', sans-serif);
     font-size: 0.6rem; color: var(--app-text-muted, rgba(255, 255, 255, 0.4));
 }
+
+/* ═══════════════════════════════════════════════════
+   CLASSIFICAÇÃO — Tabela inline na LP
+   ═══════════════════════════════════════════════════ */
+.brasileirao-class-card {
+    background: var(--app-surface, #1a1a1a);
+    border: 1px solid var(--app-border, rgba(255,255,255,0.08));
+    border-radius: 0.75rem;
+    overflow: hidden;
+    margin: 0.5rem 0;
+}
+.brasileirao-class-header {
+    display: flex; align-items: center; gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--app-border, rgba(255,255,255,0.06));
+}
+.brasileirao-class-title {
+    font-family: var(--app-font-brand, 'Russo One', sans-serif);
+    font-size: 0.85rem; color: var(--app-text-primary, #fff); margin: 0;
+}
+.brasileirao-class-sub {
+    font-size: 0.6rem; color: var(--app-text-muted, rgba(255,255,255,0.45));
+    margin: 0; font-family: var(--app-font-base, 'Inter', sans-serif);
+}
+.brasileirao-class-table-wrap { overflow-x: auto; }
+.brasileirao-class-table {
+    width: 100%; border-collapse: collapse;
+    font-family: var(--app-font-base, 'Inter', sans-serif);
+    font-size: 0.75rem;
+}
+.brasileirao-class-table thead tr {
+    background: rgba(255,255,255,0.03);
+}
+.brasileirao-class-table th {
+    padding: 6px 8px; text-align: center;
+    font-weight: 500; font-size: 0.6rem; text-transform: uppercase;
+    color: var(--app-text-dim, rgba(255,255,255,0.35));
+    letter-spacing: 0.05em;
+}
+.brasileirao-class-table th:nth-child(2) { text-align: left; }
+.brasileirao-class-table td {
+    padding: 7px 8px; text-align: center;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+    color: var(--app-text-secondary, rgba(255,255,255,0.7));
+}
+.brasileirao-pos {
+    font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
+    font-weight: 600; font-size: 0.7rem; width: 28px;
+}
+.brasileirao-time { text-align: left !important; font-weight: 500; }
+.brasileirao-pts {
+    font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
+    font-weight: 700; color: var(--app-text-primary, #fff);
+}
+.brasileirao-j, .brasileirao-sg {
+    font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
+    font-size: 0.7rem; opacity: 0.7;
+}
+
+/* Zonas */
+.brasileirao-zona-liberta td:first-child { color: var(--app-info, #2196F3); font-weight: 700; }
+.brasileirao-zona-pre-liberta td:first-child { color: var(--app-info-light, #64B5F6); font-weight: 600; }
+.brasileirao-zona-sula td:first-child { color: var(--app-warning, #FF9800); font-weight: 600; }
+.brasileirao-zona-rebaixa td:first-child { color: var(--app-danger, #f44336); font-weight: 700; }
+.brasileirao-zona-rebaixa { background: rgba(244,67,54,0.05); }
+
+/* Meu time destaque */
+.brasileirao-row-meu {
+    background: rgba(16,185,129,0.08) !important;
+}
+.brasileirao-row-meu .brasileirao-time {
+    color: var(--app-success-light, #4CAF50); font-weight: 600;
+}
+
+/* Legenda zonas */
+.brasileirao-class-legenda {
+    display: flex; flex-wrap: wrap; gap: 0.75rem;
+    padding: 0.5rem 1rem 0.75rem; border-top: 1px solid rgba(255,255,255,0.04);
+}
+.brasileirao-leg-item {
+    display: flex; align-items: center; gap: 4px;
+    font-size: 0.55rem; color: var(--app-text-dim, rgba(255,255,255,0.4));
+    font-family: var(--app-font-base, 'Inter', sans-serif);
+}
+.brasileirao-leg-dot {
+    width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+}
+
+/* ═══════════════════════════════════════════════════
+   JOGOS DA RODADA — Cards
+   ═══════════════════════════════════════════════════ */
+.brasileirao-rodada-card, .brasileirao-info-card {
+    background: var(--app-surface, #1a1a1a);
+    border: 1px solid var(--app-border, rgba(255,255,255,0.08));
+    border-radius: 0.75rem; overflow: hidden; margin: 0.75rem 0;
+}
+.brasileirao-rodada-header, .brasileirao-info-header {
+    display: flex; align-items: center; gap: 0.4rem;
+    padding: 0.65rem 1rem; font-size: 0.8rem; font-weight: 600;
+    color: var(--app-text-primary, #fff);
+    font-family: var(--app-font-brand, 'Russo One', sans-serif);
+    border-bottom: 1px solid var(--app-border, rgba(255,255,255,0.06));
+}
+.brasileirao-jogos-lista {
+    padding: 0.5rem;
+    display: flex; flex-direction: column; gap: 0.35rem;
+}
+.brasileirao-jogo-card {
+    display: flex; align-items: center; justify-content: center; gap: 0.5rem;
+    padding: 0.6rem 0.75rem; border-radius: 0.5rem;
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.04);
+    position: relative;
+}
+.brasileirao-jogo-card--live {
+    border-color: rgba(239,68,68,0.3);
+    background: rgba(239,68,68,0.06);
+}
+.brasileirao-jogo-time {
+    font-size: 0.75rem; font-weight: 500; min-width: 90px;
+    color: var(--app-text-secondary, rgba(255,255,255,0.8));
+    font-family: var(--app-font-base, 'Inter', sans-serif);
+}
+.brasileirao-jogo-time:first-of-type { text-align: right; }
+.brasileirao-jogo-time:last-of-type { text-align: left; }
+.brasileirao-jogo-placar {
+    font-family: var(--app-font-mono, 'JetBrains Mono', monospace);
+    font-size: 0.8rem; font-weight: 700; min-width: 50px; text-align: center;
+    color: var(--app-text-primary, #fff);
+}
+.brasileirao-live-dot {
+    position: absolute; top: 6px; right: 6px;
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--app-danger, #ef4444);
+    animation: brasileirao-lp-pulse 1.5s infinite;
+}
+@keyframes brasileirao-lp-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+}
+
+/* ═══════════════════════════════════════════════════
+   INFO CAMPEONATO — Fallback cards
+   ═══════════════════════════════════════════════════ */
+.brasileirao-info-items {
+    padding: 0.5rem 0.75rem;
+    display: flex; flex-direction: column; gap: 0.25rem;
+}
+.brasileirao-info-item {
+    display: flex; align-items: center; gap: 0.6rem;
+    padding: 0.6rem 0.5rem;
+    border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+.brasileirao-info-item:last-child { border-bottom: none; }
+.brasileirao-info-item .material-icons {
+    font-size: 1.1rem; color: var(--app-success-light, #4CAF50); flex-shrink: 0;
+}
+.brasileirao-info-label {
+    font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--app-text-dim, rgba(255,255,255,0.35)); margin: 0;
+    font-family: var(--app-font-base, 'Inter', sans-serif); font-weight: 500;
+}
+.brasileirao-info-value {
+    font-size: 0.75rem; color: var(--app-text-secondary, rgba(255,255,255,0.75));
+    margin: 2px 0 0; font-family: var(--app-font-base, 'Inter', sans-serif);
+}

--- a/public/participante/fronts/brasileirao.html
+++ b/public/participante/fronts/brasileirao.html
@@ -58,4 +58,4 @@
     <div class="pb-24"></div>
 </div>
 
-<link rel="stylesheet" href="/participante/css/brasileirao-lp.css?v=20260327">
+<link rel="stylesheet" href="/participante/css/brasileirao-lp.css?v=20260402">

--- a/public/participante/js/modules/participante-brasileirao.js
+++ b/public/participante/js/modules/participante-brasileirao.js
@@ -1,82 +1,341 @@
-// PARTICIPANTE-BRASILEIRAO.JS - v1.0
+// PARTICIPANTE-BRASILEIRAO.JS - v2.0
 // Controller da Landing Page "Brasileirão Série A 2026"
-// Renderiza tabela de classificação via BrasileiraoTabela global
+// v2.0: Padrão resiliente com fallback estático (alinhado com Libertadores/Copa-BR/Copa-NE)
+//       Fetch API direto com timeout defensivo. Renderização própria no DOM.
+//       BrasileiraoTabela (home faixa) NÃO é mais dependência obrigatória.
+//
+// Fontes de dados:
+//   - API: /api/brasileirao/classificacao/:temporada (classificação dinâmica)
+//   - API: /api/brasileirao/resumo/:temporada (jogos da rodada)
+//   - Fallback: dados estáticos dos 20 times da Série A 2026
 
-if (window.Log) Log.info('BRASILEIRAO-LP', 'Carregando modulo v1.1...');
+if (window.Log) Log.info('BRASILEIRAO-LP', 'Carregando modulo v2.0...');
+
+// ═══════════════════════════════════════════════════
+// ESTADO
+// ═══════════════════════════════════════════════════
 
 let _ultimaAtualizacao = null;
 let _statusInterval = null;
+let _autoRefreshInterval = null;
+let _visibilityHandler = null;
+const _AUTO_REFRESH_MS = 5 * 60 * 1000; // 5 min
+const _FETCH_TIMEOUT_MS = 8000; // 8s (< 10s do BrasileiraoTabela, < 15s do nav timeout)
+
+// ═══════════════════════════════════════════════════
+// DADOS ESTÁTICOS — FALLBACK (Série A 2026 — 20 times)
+// ═══════════════════════════════════════════════════
+
+const TIMES_SERIE_A_2026 = [
+    { posicao: 1,  time: 'Palmeiras',           time_id: 275,  sigla: 'PAL' },
+    { posicao: 2,  time: 'Botafogo',            time_id: 263,  sigla: 'BOT' },
+    { posicao: 3,  time: 'Flamengo',            time_id: 262,  sigla: 'FLA' },
+    { posicao: 4,  time: 'Fortaleza',           time_id: 356,  sigla: 'FOR' },
+    { posicao: 5,  time: 'Internacional',        time_id: 285,  sigla: 'INT' },
+    { posicao: 6,  time: 'São Paulo',            time_id: 276,  sigla: 'SAO' },
+    { posicao: 7,  time: 'Bahia',               time_id: 265,  sigla: 'BAH' },
+    { posicao: 8,  time: 'Cruzeiro',            time_id: 283,  sigla: 'CRU' },
+    { posicao: 9,  time: 'Atlético-MG',         time_id: 282,  sigla: 'CAM' },
+    { posicao: 10, time: 'Corinthians',          time_id: 264,  sigla: 'COR' },
+    { posicao: 11, time: 'Vasco da Gama',        time_id: 267,  sigla: 'VAS' },
+    { posicao: 12, time: 'Grêmio',              time_id: 284,  sigla: 'GRE' },
+    { posicao: 13, time: 'Vitória',              time_id: 287,  sigla: 'VIT' },
+    { posicao: 14, time: 'Fluminense',           time_id: 266,  sigla: 'FLU' },
+    { posicao: 15, time: 'Athletico-PR',         time_id: 293,  sigla: 'CAP' },
+    { posicao: 16, time: 'Red Bull Bragantino',  time_id: 280,  sigla: 'RBB' },
+    { posicao: 17, time: 'Juventude',            time_id: 286,  sigla: 'JUV' },
+    { posicao: 18, time: 'Santos',               time_id: 277,  sigla: 'SAN' },
+    { posicao: 19, time: 'Sport',                time_id: 292,  sigla: 'SPT' },
+    { posicao: 20, time: 'Mirassol',             time_id: 2305, sigla: 'MIR' },
+];
+
+const INFO_CAMPEONATO = {
+    formato: '38 rodadas — pontos corridos (turno e returno)',
+    inicio: 'Março 2026',
+    termino: 'Dezembro 2026',
+    times: 20,
+    jogos_total: 380,
+    vagas_liberta: '4 primeiros → Libertadores 2027',
+    vagas_sula: '5º ao 12º → Sul-Americana 2027',
+    rebaixamento: '17º ao 20º → Série B 2027',
+};
+
+// ═══════════════════════════════════════════════════
+// UTILS
+// ═══════════════════════════════════════════════════
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+async function _fetchComTimeout(url) {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), _FETCH_TIMEOUT_MS);
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        clearTimeout(t);
+        return res;
+    } catch (err) {
+        clearTimeout(t);
+        throw err;
+    }
+}
+
+// ═══════════════════════════════════════════════════
+// INICIALIZAÇÃO — Padrão resiliente (igual Copa-NE/Copa-BR/Libertadores)
+// ═══════════════════════════════════════════════════
 
 export async function inicializarBrasileraoParticipante() {
+    if (window.Log) Log.info('BRASILEIRAO-LP', 'Inicializando LP Brasileirão 2026 v2.0...');
+
+    // Registrar cleanup no window para o navigation poder chamar ao sair
+    window.destruirBrasileraoParticipante = destruirBrasileraoParticipante;
+
     try {
-        // Lazy-load do BrasileiraoTabela se ainda não foi carregado
-        if (!window.BrasileiraoTabela) {
-            try {
-                await import('../brasileirao-tabela.js');
-            } catch (importErr) {
-                if (window.Log) Log.warn('BRASILEIRAO-LP', 'Falha no lazy-load:', importErr.message);
-            }
-        }
-
-        if (!window.BrasileiraoTabela) {
-            const container = document.getElementById('brasileirao-classificacao-container');
-            if (container) {
-                container.innerHTML = `
-                    <div class="text-center py-6">
-                        <span class="material-icons text-2xl" style="color: var(--app-text-dim);">table_chart</span>
-                        <p class="text-gray-500 mt-2 text-xs">Tabela não disponível</p>
-                    </div>
-                `;
-            }
-            return;
-        }
-
-        // Renderizar classificação e jogos da rodada em paralelo
-        await Promise.all([
-            window.BrasileiraoTabela.renderizarClassificacao('brasileirao-classificacao-container'),
-            window.BrasileiraoTabela.renderizar({
-                containerId: 'brasileirao-tabela-container',
-                temporada: new Date().getFullYear()
-            })
+        // Carregar dados dinâmicos em paralelo (com timeout defensivo)
+        const [apiClassificacao, apiResumo] = await Promise.all([
+            _carregarClassificacao(),
+            _carregarResumo(),
         ]);
+
+        // Renderizar — usa fallback se API retornou null
+        _renderizarClassificacao(apiClassificacao);
+        _renderizarJogosRodada(apiResumo);
 
         _ultimaAtualizacao = Date.now();
         _atualizarStatus();
         _setupRefreshButton();
+        _iniciarAutoRefresh();
         _statusInterval = setInterval(_atualizarStatus, 60000);
+
+        if (window.Log) Log.info('BRASILEIRAO-LP', apiClassificacao ? 'LP com dados dinâmicos' : 'LP com dados estáticos (fallback)');
     } catch (err) {
-        if (window.Log) Log.warn('BRASILEIRAO-LP', 'Erro ao renderizar:', err);
-
-        // Limpar spinners que ficaram presos
-        const classContainer = document.getElementById('brasileirao-classificacao-container');
-        if (classContainer && classContainer.querySelector('[role="status"]')) {
-            classContainer.innerHTML = `
-                <div class="text-center py-6">
-                    <span class="material-icons text-2xl" style="color: var(--app-danger);">error_outline</span>
-                    <p class="text-gray-500 mt-2 text-xs">Erro ao carregar dados</p>
-                </div>
-            `;
-        }
-
-        const tabelaContainer = document.getElementById('brasileirao-tabela-container');
-        if (tabelaContainer && !tabelaContainer.innerHTML.trim()) {
-            tabelaContainer.innerHTML = `
-                <div class="text-center py-6">
-                    <span class="material-icons text-2xl" style="color: var(--app-danger);">error_outline</span>
-                    <p class="text-gray-500 mt-2 text-xs">Erro ao carregar jogos</p>
-                </div>
-            `;
-        }
+        if (window.Log) Log.warn('BRASILEIRAO-LP', 'Erro na inicialização, usando fallback:', err);
+        _renderizarFallbackCompleto();
     }
 }
 
 export function destruirBrasileraoParticipante() {
-    if (window.BrasileiraoTabela && typeof window.BrasileiraoTabela.destruir === 'function') {
-        window.BrasileiraoTabela.destruir();
-    }
+    _pararAutoRefresh();
     if (_statusInterval) { clearInterval(_statusInterval); _statusInterval = null; }
     _ultimaAtualizacao = null;
 }
+
+// ═══════════════════════════════════════════════════
+// API — Fetches diretos com try/catch (retornam data ou null)
+// ═══════════════════════════════════════════════════
+
+async function _carregarClassificacao() {
+    try {
+        const temporada = new Date().getFullYear();
+        const res = await _fetchComTimeout(`/api/brasileirao/classificacao/${temporada}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        return (data.success && data.classificacao && data.classificacao.length > 0) ? data : null;
+    } catch (err) {
+        if (window.Log) Log.warn('BRASILEIRAO-LP', 'API classificação indisponível:', err.message);
+        return null;
+    }
+}
+
+async function _carregarResumo() {
+    try {
+        const temporada = new Date().getFullYear();
+        const res = await _fetchComTimeout(`/api/brasileirao/resumo/${temporada}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        return data.success ? data : null;
+    } catch (err) {
+        if (window.Log) Log.warn('BRASILEIRAO-LP', 'API resumo indisponível:', err.message);
+        return null;
+    }
+}
+
+// ═══════════════════════════════════════════════════
+// RENDERIZAÇÃO — CLASSIFICAÇÃO (dinâmica ou fallback)
+// ═══════════════════════════════════════════════════
+
+function _renderizarClassificacao(apiData) {
+    const container = document.getElementById('brasileirao-classificacao-container');
+    if (!container) return;
+
+    const classificacao = apiData?.classificacao || TIMES_SERIE_A_2026;
+    const rodadaAtual = apiData?.rodada_atual || null;
+    const isFallback = !apiData;
+
+    // Resolver clube do participante para destaque
+    const meuClubeId = window.participanteAuth?.participante?.participante?.clube_id
+                    || window.participanteAuth?.participante?.clube_id
+                    || null;
+
+    const zonaClass = (pos) => {
+        if (pos <= 4) return 'brasileirao-zona-liberta';
+        if (pos <= 6) return 'brasileirao-zona-pre-liberta';
+        if (pos <= 12) return 'brasileirao-zona-sula';
+        if (pos <= 16) return '';
+        return 'brasileirao-zona-rebaixa';
+    };
+
+    const headerSub = isFallback
+        ? 'Aguardando dados — classificação provisória'
+        : `Após ${rodadaAtual}ª rodada`;
+
+    const rows = classificacao.map(t => {
+        const pos = t.posicao;
+        const isMeu = meuClubeId && Number(t.time_id) === Number(meuClubeId);
+        const zona = zonaClass(pos);
+        const meuClass = isMeu ? ' brasileirao-row-meu' : '';
+
+        if (isFallback) {
+            return `<tr class="${zona}${meuClass}">
+                <td class="brasileirao-pos">${pos}</td>
+                <td class="brasileirao-time">${escapeHtml(t.time)}</td>
+                <td class="brasileirao-pts" style="opacity:0.4">-</td>
+                <td class="brasileirao-j" style="opacity:0.4">-</td>
+                <td class="brasileirao-sg" style="opacity:0.4">-</td>
+            </tr>`;
+        }
+
+        return `<tr class="${zona}${meuClass}">
+            <td class="brasileirao-pos">${pos}</td>
+            <td class="brasileirao-time">${escapeHtml(t.time)}</td>
+            <td class="brasileirao-pts">${t.pontos}</td>
+            <td class="brasileirao-j">${t.jogos}</td>
+            <td class="brasileirao-sg">${t.saldo > 0 ? '+' : ''}${t.saldo}</td>
+        </tr>`;
+    }).join('');
+
+    container.innerHTML = `
+        <div class="brasileirao-class-card">
+            <div class="brasileirao-class-header">
+                <span class="material-icons" style="color: var(--app-success-light); font-size: 1.1rem;">leaderboard</span>
+                <div>
+                    <p class="brasileirao-class-title">Classificação</p>
+                    <p class="brasileirao-class-sub">${headerSub}</p>
+                </div>
+            </div>
+            <div class="brasileirao-class-table-wrap">
+                <table class="brasileirao-class-table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Time</th>
+                            <th>P</th>
+                            <th>J</th>
+                            <th>SG</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </div>
+            <div class="brasileirao-class-legenda">
+                <span class="brasileirao-leg-item"><span class="brasileirao-leg-dot" style="background:#1B5E20;"></span>Libertadores</span>
+                <span class="brasileirao-leg-item"><span class="brasileirao-leg-dot" style="background:#2E7D32;"></span>Pré-Libertadores</span>
+                <span class="brasileirao-leg-item"><span class="brasileirao-leg-dot" style="background:#FF9800;"></span>Sul-Americana</span>
+                <span class="brasileirao-leg-item"><span class="brasileirao-leg-dot" style="background:#c62828;"></span>Rebaixamento</span>
+            </div>
+        </div>
+    `;
+}
+
+// ═══════════════════════════════════════════════════
+// RENDERIZAÇÃO — JOGOS DA RODADA (dinâmico ou fallback info)
+// ═══════════════════════════════════════════════════
+
+function _renderizarJogosRodada(apiData) {
+    const container = document.getElementById('brasileirao-tabela-container');
+    if (!container) return;
+
+    if (apiData && apiData.jogos_rodada_atual && apiData.jogos_rodada_atual.length > 0) {
+        // Renderizar jogos reais
+        const rodada = apiData.rodada_atual || '?';
+        const jogosHtml = apiData.jogos_rodada_atual.map(j => {
+            const statusClass = j.status === 'ao_vivo' ? ' brasileirao-jogo--live' : '';
+            const liveDot = j.status === 'ao_vivo' ? '<span class="brasileirao-live-dot"></span>' : '';
+            const placar = j.placar_mandante !== null && j.placar_mandante !== undefined
+                ? `${j.placar_mandante} x ${j.placar_visitante}`
+                : j.horario || 'A definir';
+
+            return `<div class="brasileirao-jogo-card${statusClass}">
+                ${liveDot}
+                <span class="brasileirao-jogo-time">${escapeHtml(j.mandante)}</span>
+                <span class="brasileirao-jogo-placar">${placar}</span>
+                <span class="brasileirao-jogo-time">${escapeHtml(j.visitante)}</span>
+            </div>`;
+        }).join('');
+
+        container.innerHTML = `
+            <div class="brasileirao-rodada-card">
+                <div class="brasileirao-rodada-header">
+                    <span class="material-icons" style="color: var(--app-success-light); font-size: 1rem;">sports_soccer</span>
+                    <span>Rodada ${rodada}</span>
+                </div>
+                <div class="brasileirao-jogos-lista">${jogosHtml}</div>
+            </div>
+        `;
+    } else {
+        // Fallback: info do campeonato (mesmo padrão das fases do Copa-NE/Copa-BR)
+        container.innerHTML = `
+            <div class="brasileirao-info-card">
+                <div class="brasileirao-info-header">
+                    <span class="material-icons" style="color: var(--app-success-light); font-size: 1rem;">info</span>
+                    <span>Sobre o Campeonato</span>
+                </div>
+                <div class="brasileirao-info-items">
+                    <div class="brasileirao-info-item">
+                        <span class="material-icons">calendar_month</span>
+                        <div>
+                            <p class="brasileirao-info-label">Período</p>
+                            <p class="brasileirao-info-value">${INFO_CAMPEONATO.inicio} a ${INFO_CAMPEONATO.termino}</p>
+                        </div>
+                    </div>
+                    <div class="brasileirao-info-item">
+                        <span class="material-icons">format_list_numbered</span>
+                        <div>
+                            <p class="brasileirao-info-label">Formato</p>
+                            <p class="brasileirao-info-value">${INFO_CAMPEONATO.formato}</p>
+                        </div>
+                    </div>
+                    <div class="brasileirao-info-item">
+                        <span class="material-icons">emoji_events</span>
+                        <div>
+                            <p class="brasileirao-info-label">Libertadores</p>
+                            <p class="brasileirao-info-value">${INFO_CAMPEONATO.vagas_liberta}</p>
+                        </div>
+                    </div>
+                    <div class="brasileirao-info-item">
+                        <span class="material-icons">trending_down</span>
+                        <div>
+                            <p class="brasileirao-info-label">Rebaixamento</p>
+                            <p class="brasileirao-info-value">${INFO_CAMPEONATO.rebaixamento}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+}
+
+// ═══════════════════════════════════════════════════
+// FALLBACK COMPLETO (catch do try principal)
+// ═══════════════════════════════════════════════════
+
+function _renderizarFallbackCompleto() {
+    _renderizarClassificacao(null);
+    _renderizarJogosRodada(null);
+    _ultimaAtualizacao = Date.now();
+    _atualizarStatus();
+    _setupRefreshButton();
+}
+
+// ═══════════════════════════════════════════════════
+// REFRESH BUTTON + AUTO-REFRESH (padrão Copa-NE/Libertadores)
+// ═══════════════════════════════════════════════════
 
 function _setupRefreshButton() {
     const btn = document.getElementById('brasileirao-refresh');
@@ -87,20 +346,57 @@ function _setupRefreshButton() {
         btn.disabled = true;
         icon.classList.add('spinning');
         try {
-            if (window.BrasileiraoTabela) {
-                await Promise.all([
-                    window.BrasileiraoTabela.renderizarClassificacao('brasileirao-classificacao-container'),
-                    window.BrasileiraoTabela.renderizar({
-                        containerId: 'brasileirao-tabela-container',
-                        temporada: new Date().getFullYear()
-                    })
-                ]);
-                _ultimaAtualizacao = Date.now();
-                _atualizarStatus();
-            }
-        } finally { icon.classList.remove('spinning'); btn.disabled = false; }
+            const [apiClassificacao, apiResumo] = await Promise.all([
+                _carregarClassificacao(),
+                _carregarResumo(),
+            ]);
+            _renderizarClassificacao(apiClassificacao);
+            _renderizarJogosRodada(apiResumo);
+            _ultimaAtualizacao = Date.now();
+            _atualizarStatus();
+        } finally {
+            icon.classList.remove('spinning');
+            btn.disabled = false;
+        }
     });
 }
+
+function _iniciarAutoRefresh() {
+    _pararAutoRefresh();
+    _autoRefreshInterval = setInterval(() => {
+        if (!document.hidden) _atualizarDados();
+    }, _AUTO_REFRESH_MS);
+    _visibilityHandler = () => {
+        if (!document.hidden && _ultimaAtualizacao && (Date.now() - _ultimaAtualizacao > _AUTO_REFRESH_MS)) {
+            _atualizarDados();
+        }
+    };
+    document.addEventListener('visibilitychange', _visibilityHandler);
+}
+
+function _pararAutoRefresh() {
+    if (_autoRefreshInterval) { clearInterval(_autoRefreshInterval); _autoRefreshInterval = null; }
+    if (_visibilityHandler) { document.removeEventListener('visibilitychange', _visibilityHandler); _visibilityHandler = null; }
+}
+
+async function _atualizarDados() {
+    try {
+        const [apiClassificacao, apiResumo] = await Promise.all([
+            _carregarClassificacao(),
+            _carregarResumo(),
+        ]);
+        if (apiClassificacao) _renderizarClassificacao(apiClassificacao);
+        if (apiResumo) _renderizarJogosRodada(apiResumo);
+        _ultimaAtualizacao = Date.now();
+        _atualizarStatus();
+    } catch (err) {
+        if (window.Log) Log.warn('BRASILEIRAO-LP', 'Erro no auto-refresh:', err.message);
+    }
+}
+
+// ═══════════════════════════════════════════════════
+// STATUS (padrão Libertadores/Copa-NE)
+// ═══════════════════════════════════════════════════
 
 function _atualizarStatus() {
     const el = document.getElementById('brasileirao-status');

--- a/services/brasileirao-tabela-service.js
+++ b/services/brasileirao-tabela-service.js
@@ -152,26 +152,30 @@ function formatarHora(dataISO) {
 // FONTE 1: ESPN (gratuita, sem autenticação, calendário completo)
 // =====================================================================
 
-// Mapeamento ESPN displayName → ID Cartola
+// Mapeamento ESPN displayName → ID Cartola (Série A 2026 — 20 times)
 const TIMES_ESPN_MAP = {
     'Athletico-PR':       293,
+    'Athletico Paranaense': 293,
     'Atlético-MG':        282,
+    'Atlético Mineiro':   282,
     'Bahia':              265,
     'Botafogo':           263,
-    'Chapecoense':        315,
     'Corinthians':        264,
-    'Coritiba':           270,
     'Cruzeiro':           283,
     'Flamengo':           262,
     'Fluminense':         266,
+    'Fortaleza':          356,
     'Grêmio':             284,
     'Internacional':      285,
+    'Juventude':          286,
     'Mirassol':           2305,
     'Palmeiras':          275,
     'Red Bull Bragantino': 280,
-    'Remo':               1044,
+    'RB Bragantino':      280,
     'Santos':             277,
     'São Paulo':          276,
+    'Sport':              292,
+    'Sport Recife':       292,
     'Vasco da Gama':      267,
     'Vitória':            287,
 };
@@ -784,9 +788,13 @@ async function obterResumoAoVivo(temporada) {
 
     try {
         // Buscar jogos ao vivo internamente (via fetch local)
+        // node-fetch v3 não suporta 'timeout' — usar AbortController
+        const aoVivoController = new AbortController();
+        const aoVivoTimeoutId = setTimeout(() => aoVivoController.abort(), 10000);
         const response = await fetch(`http://localhost:${process.env.PORT || 3000}/api/jogos-ao-vivo`, {
-            timeout: 10000,
+            signal: aoVivoController.signal,
         });
+        clearTimeout(aoVivoTimeoutId);
 
         if (!response.ok) {
             throw new Error(`HTTP ${response.status}`);


### PR DESCRIPTION
## Summary

- **Corrigir loading infinito** ao navegar Especial → Brasileirão: módulo LP agora segue o padrão resiliente com fallback estático (igual Libertadores/Copa-BR/Copa-NE)
- **Corrigir `TIMES_ESPN_MAP`** com elenco real da Série A 2026 (faltavam Fortaleza, Sport, Juventude; sobravam Chapecoense, Coritiba, Remo)
- **Corrigir timeout silencioso** do `node-fetch` v3 em `obterResumoAoVivo` (substituído `timeout:10000` ignorado por `AbortController`)

### Causa raiz

O módulo Brasileirão era 100% dependente de APIs externas (ESPN + Cartola + matchday) sem dados de fallback. Os outros 3 módulos Especial funcionam porque têm dados estáticos hardcoded — se a API falha, renderizam conteúdo estático.

### Arquivos modificados (4)

| Arquivo | Mudança |
|---------|---------|
| `services/brasileirao-tabela-service.js` | Fix TIMES_ESPN_MAP 2026 + fix timeout node-fetch v3 |
| `public/participante/js/modules/participante-brasileirao.js` | Reescrito v2.0 com padrão resiliente + fallback estático |
| `public/participante/css/brasileirao-lp.css` | Estilos para classificação, jogos e info cards na LP |
| `public/participante/fronts/brasileirao.html` | Cache bust CSS |

## Test plan

- [ ] Abrir app participante → Menu Especial → Clicar Brasileirão
- [ ] Verificar que mostra classificação (dinâmica ou fallback estático dos 20 times)
- [ ] Verificar que mostra jogos da rodada OU info do campeonato (fallback)
- [ ] Confirmar que spinner NUNCA fica infinito (sempre renderiza algo em < 8s)
- [ ] Confirmar que as outras 4 opções Especial continuam funcionando
- [ ] Confirmar que a faixa Brasileirão na HOME page continua funcionando

https://claude.ai/code/session_0189R5q2tM7MXY7EjnqG1qFx