### PR TITLE
fix(mata-mata): auditoria completa do módulo — 4 bugs corrigidos

### DIFF
--- a/public/js/mata-mata/mata-mata-orquestrador.js
+++ b/public/js/mata-mata/mata-mata-orquestrador.js
@@ -453,7 +453,8 @@ export async function carregarMataMata() {
       const mercadoAberto = data.status_mercado === 1;
       const temporadaAPI = data.temporada || new Date().getFullYear();
       const anoAtual = new Date().getFullYear();
-      const RODADA_FINAL_CAMPEONATO = data.rodada_final || RODADA_FINAL_CAMPEONATO;
+      // ✅ FIX: Usar nome diferente para evitar TDZ (const local não pode referenciar a si mesma)
+      const rodadaFinalCamp = data.rodada_final || RODADA_FINAL_CAMPEONATO;
 
       // v1.4: Detecção dinâmica de temporada com verificação do ano
       if (rodadaAtual === 1 && mercadoAberto) {
@@ -468,7 +469,7 @@ export async function carregarMataMata() {
         }
         // Pré-temporada real: usar rodada 38 da anterior
         console.log("[MATA-ORQUESTRADOR] Pré-temporada - usando rodada 38 da temporada anterior");
-        rodadaAtual = RODADA_FINAL_CAMPEONATO;
+        rodadaAtual = rodadaFinalCamp;
       }
 
       // ✅ Guardar rodada atual global para bloqueio de fases futuras
@@ -814,7 +815,8 @@ function atualizarNavegacaoFases(fasesAtivas) {
       let isDisabled = false;
       if (edicaoSelecionada && rodadaAtualGlobal > 0) {
         const rodadaDaFase = edicaoSelecionada.rodadaInicial + idx;
-        isDisabled = rodadaAtualGlobal <= rodadaDaFase;
+        // ✅ FIX: Usar < (não <=) para permitir clique na fase da rodada atual (ao vivo)
+        isDisabled = rodadaAtualGlobal < rodadaDaFase;
       }
       const disabledClass = isDisabled ? " disabled" : "";
       const lockIcon = isDisabled ? ' 🔒' : '';
@@ -928,7 +930,8 @@ async function carregarFase(fase, ligaId) {
         statusMercadoGlobal = data.status_mercado; // ✅ v2.2: Capturar para detecção isLive
         const temporadaAPI = data.temporada || new Date().getFullYear();
         const anoAtual = new Date().getFullYear();
-        const RODADA_FINAL_CAMPEONATO = data.rodada_final || RODADA_FINAL_CAMPEONATO;
+        // ✅ FIX: Usar nome diferente para evitar TDZ (const local não pode referenciar a si mesma)
+        const rodadaFinalCamp = data.rodada_final || RODADA_FINAL_CAMPEONATO;
 
         // v1.4: Detecção dinâmica de temporada com verificação do ano
         if (rodada_atual === 1 && mercadoAberto) {
@@ -938,7 +941,7 @@ async function carregarFase(fase, ligaId) {
             isTemporadaAnterior = false;
           } else {
             console.log("[MATA-ORQUESTRADOR] Pré-temporada - usando rodada 38 para cálculo de fases");
-            rodada_atual = RODADA_FINAL_CAMPEONATO;
+            rodada_atual = rodadaFinalCamp;
             isTemporadaAnterior = true;
           }
         }

--- a/routes/mataMataCacheRoutes.js
+++ b/routes/mataMataCacheRoutes.js
@@ -66,7 +66,9 @@ function validarEdicaoParam(req, res, next) {
 }
 
 // ============================================================================
-// 📋 ROTA PARA LISTAR TODAS AS EDIÇÕES DISPONÍVEIS NO CACHE
+// 📋 ROTA PARA LISTAR TODAS AS EDIÇÕES DISPONÍVEIS
+// ✅ FIX: Cruza MataMataCache com calendario_efetivo da ModuleConfig
+//    para que edições sem cache (ainda não consolidadas) apareçam no dropdown
 // ⚠️ IMPORTANTE: Esta rota DEVE vir ANTES da rota com parâmetro :edicao
 // ============================================================================
 router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
@@ -76,14 +78,15 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
         const temporadaFiltro = temporada ? parseInt(temporada) : CURRENT_SEASON;
 
         console.log(
-            `[MATA-CACHE] 📋 Listando edições disponíveis para liga ${ligaId}, temporada ${temporadaFiltro}`,
+            `[MATA-CACHE] 📋 Listando edições para liga ${ligaId}, temporada ${temporadaFiltro}`,
         );
 
         const MataMataCache = (await import("../models/MataMataCache.js"))
             .default;
+        const ModuleConfig = (await import("../models/ModuleConfig.js")).default;
 
-        // Buscar edições APENAS da temporada especificada
-        const edicoes = await MataMataCache.find({
+        // 1. Buscar edições existentes no cache
+        const edicoesCache = await MataMataCache.find({
             liga_id: ligaId,
             temporada: temporadaFiltro
         })
@@ -91,28 +94,92 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
             .sort({ edicao: 1 })
             .lean();
 
-        if (edicoes.length === 0) {
+        // Mapa de edições com cache para lookup rápido
+        const cacheMap = new Map();
+        edicoesCache.forEach(ed => cacheMap.set(ed.edicao, ed));
+
+        // 2. Buscar calendario_efetivo da ModuleConfig (fonte de verdade do admin)
+        let edicoesCalendario = [];
+        try {
+            const moduleConfig = await ModuleConfig.findOne({
+                liga_id: ligaId,
+                modulo: 'mata_mata',
+                temporada: temporadaFiltro
+            }).lean();
+
+            if (moduleConfig?.calendario_override?.length > 0) {
+                edicoesCalendario = moduleConfig.calendario_override;
+            } else if (moduleConfig?.wizard_respostas?.total_times && moduleConfig?.wizard_respostas?.qtd_edicoes) {
+                // Gerar dinamicamente (mesmo algoritmo de module-config-routes.js)
+                const totalTimes = Number(moduleConfig.wizard_respostas.total_times);
+                const qtdEdicoes = Number(moduleConfig.wizard_respostas.qtd_edicoes);
+                let numFases;
+                if (totalTimes >= 32) numFases = 5;
+                else if (totalTimes >= 16) numFases = 4;
+                else if (totalTimes >= 8) numFases = 3;
+                else numFases = 0;
+
+                if (numFases > 0) {
+                    let rodadaAtual = 2;
+                    for (let i = 0; i < qtdEdicoes; i++) {
+                        const rodadaDefinicao = rodadaAtual;
+                        const rodadaInicial = rodadaDefinicao + 1;
+                        const rodadaFinal = rodadaInicial + numFases - 1;
+                        if (rodadaFinal > 38) break;
+                        edicoesCalendario.push({
+                            edicao: i + 1,
+                            nome: `${i + 1}ª Edição`,
+                            rodada_inicial: rodadaInicial,
+                            rodada_final: rodadaFinal,
+                            rodada_definicao: rodadaDefinicao
+                        });
+                        rodadaAtual = rodadaFinal + 1;
+                    }
+                }
+            }
+        } catch (err) {
+            console.warn(`[MATA-CACHE] ⚠️ Erro ao buscar calendario_efetivo:`, err.message);
+        }
+
+        // 3. Mesclar: todas as edições do calendário, enriquecidas com dados do cache
+        let resumo;
+        if (edicoesCalendario.length > 0) {
+            resumo = edicoesCalendario.map(cal => {
+                const edicaoNum = cal.edicao;
+                const cached = cacheMap.get(edicaoNum);
+                return {
+                    edicao: edicaoNum,
+                    rodada_salva: cached?.rodada_atual || null,
+                    ultima_atualizacao: cached?.ultima_atualizacao || null,
+                    cache_id: cached?._id || null,
+                    cache_disponivel: !!cached,
+                };
+            });
+        } else {
+            // Fallback: retornar apenas edições do cache (sem ModuleConfig)
+            resumo = edicoesCache.map(ed => ({
+                edicao: ed.edicao,
+                rodada_salva: ed.rodada_atual,
+                ultima_atualizacao: ed.ultima_atualizacao,
+                cache_id: ed._id,
+                cache_disponivel: true,
+            }));
+        }
+
+        if (resumo.length === 0) {
             return res.json({
                 liga_id: ligaId,
                 total: 0,
                 edicoes: [],
-                mensagem: "Nenhuma edição encontrada no cache",
+                mensagem: "Nenhuma edição encontrada",
             });
         }
 
-        // Formatar resposta
-        const resumo = edicoes.map((ed) => ({
-            edicao: ed.edicao,
-            rodada_salva: ed.rodada_atual,
-            ultima_atualizacao: ed.ultima_atualizacao,
-            cache_id: ed._id,
-        }));
-
-        console.log(`[MATA-CACHE] ✅ Encontradas ${edicoes.length} edições`);
+        console.log(`[MATA-CACHE] ✅ ${resumo.length} edições (${edicoesCache.length} com cache, ${edicoesCalendario.length} no calendário)`);
 
         res.json({
             liga_id: ligaId,
-            total: edicoes.length,
+            total: resumo.length,
             edicoes: resumo,
         });
     } catch (error) {

--- a/routes/mataMataCacheRoutes.js
+++ b/routes/mataMataCacheRoutes.js
@@ -100,12 +100,14 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
 
         // 2. Buscar calendario_efetivo da ModuleConfig (fonte de verdade do admin)
         let edicoesCalendario = [];
+        let wizardTotalTimes = null;
         try {
             const moduleConfig = await ModuleConfig.findOne({
                 liga_id: ligaId,
                 modulo: 'mata_mata',
                 temporada: temporadaFiltro
             }).lean();
+            wizardTotalTimes = moduleConfig?.wizard_respostas?.total_times ? Number(moduleConfig.wizard_respostas.total_times) : null;
 
             if (moduleConfig?.calendario_override?.length > 0) {
                 edicoesCalendario = moduleConfig.calendario_override;
@@ -141,14 +143,80 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
             console.warn(`[MATA-CACHE] ⚠️ Erro ao buscar calendario_efetivo:`, err.message);
         }
 
-        // 3. Mesclar: todas as edições do calendário, enriquecidas com dados do cache
+        // 3. Determinar rodada atual para calcular fase_atual e status de cada edição
+        let rodadaAtualGlobal = null;
+        try {
+            const cartolaApiService = (await import("../services/cartolaApiService.js")).default;
+            const mercado = await cartolaApiService.obterStatusMercado();
+            rodadaAtualGlobal = mercado?.rodada_atual || mercado?.rodadaAtual || null;
+        } catch (err) {
+            console.warn(`[MATA-CACHE] ⚠️ Não foi possível obter rodada atual:`, err.message);
+        }
+
+        // Helper: calcular fases para tamanho do torneio
+        function getFasesParaTamanho(tamanho) {
+            if (tamanho >= 32) return ["primeira", "oitavas", "quartas", "semis", "final"];
+            if (tamanho >= 16) return ["oitavas", "quartas", "semis", "final"];
+            if (tamanho >= 8) return ["quartas", "semis", "final"];
+            return [];
+        }
+
+        // Determinar tamanho do torneio (reusa wizard_respostas do bloco 2)
+        const tamanhoTorneio = (wizardTotalTimes && [8, 16, 32].includes(wizardTotalTimes)) ? wizardTotalTimes : 32;
+
+        const fasesDoTorneio = getFasesParaTamanho(tamanhoTorneio);
+        const FASE_LABELS = { primeira: "1ª FASE", oitavas: "OITAVAS", quartas: "QUARTAS", semis: "SEMIS", final: "FINAL" };
+
+        // 4. Mesclar: todas as edições do calendário, com calendário + rodada classificação + fase atual
         let resumo;
         if (edicoesCalendario.length > 0) {
             resumo = edicoesCalendario.map(cal => {
                 const edicaoNum = cal.edicao;
                 const cached = cacheMap.get(edicaoNum);
+
+                // Normalizar campos (calendario_override usa snake_case, JSON usa camelCase)
+                const rodadaInicial = cal.rodada_inicial || cal.rodadaInicial;
+                const rodadaFinal = cal.rodada_final || cal.rodadaFinal;
+                const rodadaDefinicao = cal.rodada_definicao || cal.rodadaDefinicao;
+
+                // Calcular fase_atual e status baseado na rodada global
+                let fase_atual = null;
+                let status_edicao = "pendente";
+                if (rodadaAtualGlobal !== null) {
+                    if (rodadaAtualGlobal < rodadaDefinicao) {
+                        status_edicao = "pendente";
+                    } else if (rodadaAtualGlobal === rodadaDefinicao) {
+                        status_edicao = "classificacao";
+                        fase_atual = "classificacao";
+                    } else if (rodadaAtualGlobal >= rodadaInicial && rodadaAtualGlobal <= rodadaFinal) {
+                        status_edicao = "em_andamento";
+                        const idxFase = Math.min(rodadaAtualGlobal - rodadaInicial, fasesDoTorneio.length - 1);
+                        fase_atual = fasesDoTorneio[idxFase] || null;
+                    } else if (rodadaAtualGlobal > rodadaFinal) {
+                        status_edicao = "encerrada";
+                        fase_atual = "final";
+                    }
+                }
+
                 return {
                     edicao: edicaoNum,
+                    nome: cal.nome || `${edicaoNum}ª Edição`,
+                    // Calendário completo
+                    calendario: {
+                        rodada_definicao: rodadaDefinicao,
+                        rodada_inicial: rodadaInicial,
+                        rodada_final: rodadaFinal,
+                        fases: fasesDoTorneio.map((f, idx) => ({
+                            fase: f,
+                            label: FASE_LABELS[f],
+                            rodada: rodadaInicial + idx
+                        }))
+                    },
+                    // Status atual
+                    status_edicao,
+                    fase_atual,
+                    fase_atual_label: fase_atual ? (FASE_LABELS[fase_atual] || fase_atual.toUpperCase()) : null,
+                    // Cache
                     rodada_salva: cached?.rodada_atual || null,
                     ultima_atualizacao: cached?.ultima_atualizacao || null,
                     cache_id: cached?._id || null,
@@ -159,6 +227,11 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
             // Fallback: retornar apenas edições do cache (sem ModuleConfig)
             resumo = edicoesCache.map(ed => ({
                 edicao: ed.edicao,
+                nome: `${ed.edicao}ª Edição`,
+                calendario: null,
+                status_edicao: "desconhecido",
+                fase_atual: null,
+                fase_atual_label: null,
                 rodada_salva: ed.rodada_atual,
                 ultima_atualizacao: ed.ultima_atualizacao,
                 cache_id: ed._id,
@@ -171,15 +244,19 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
                 liga_id: ligaId,
                 total: 0,
                 edicoes: [],
+                rodada_atual: rodadaAtualGlobal,
+                tamanho_torneio: tamanhoTorneio,
                 mensagem: "Nenhuma edição encontrada",
             });
         }
 
-        console.log(`[MATA-CACHE] ✅ ${resumo.length} edições (${edicoesCache.length} com cache, ${edicoesCalendario.length} no calendário)`);
+        console.log(`[MATA-CACHE] ✅ ${resumo.length} edições (${edicoesCache.length} com cache, ${edicoesCalendario.length} no calendário, rodada=${rodadaAtualGlobal})`);
 
         res.json({
             liga_id: ligaId,
             total: resumo.length,
+            rodada_atual: rodadaAtualGlobal,
+            tamanho_torneio: tamanhoTorneio,
             edicoes: resumo,
         });
     } catch (error) {

--- a/routes/module-config-routes.js
+++ b/routes/module-config-routes.js
@@ -556,6 +556,16 @@ router.put('/liga/:ligaId/modulos/:modulo/config', verificarAdmin, async (req, r
                     );
                     console.log(`[MODULE-CONFIG] calendario_override gerado para mata_mata: ${calendarioGerado.length} edições (${wizard_respostas.total_times} times)`);
                 }
+
+                // ✅ FIX: Invalidar MataMataCache ao reconfigurar wizard
+                // Caches antigos podem ter dados baseados em rodadas de calendário anterior
+                const MataMataCache = (await import('../models/MataMataCache.js')).default;
+                const ligaIdQuery = mongoose.Types.ObjectId.isValid(ligaId) ? new mongoose.Types.ObjectId(ligaId) : ligaId;
+                const mmDeleted = await MataMataCache.deleteMany({
+                    liga_id: String(ligaIdQuery),
+                    temporada: Number(temporada)
+                });
+                console.log(`[MODULE-CONFIG] MataMataCache invalidado para liga ${ligaId}: ${mmDeleted.deletedCount} entradas removidas`);
             }
 
             // ✅ v11.0: Invalidar cache do melhor_mes quando edições são reconfiguradas


### PR DESCRIPTION
BUG 1 (CRÍTICO): Fix TDZ crash latente no orquestrador
- `const RODADA_FINAL_CAMPEONATO = data.rodada_final || RODADA_FINAL_CAMPEONATO`
  referenciava a própria const em temporal dead zone — crash se API
  não retornasse rodada_final. Renomeado para `rodadaFinalCamp`.
- Corrigido em carregarMataMata() e carregarFase().

BUG 2 (ALTO): Fix off-by-one no bloqueio de botões de fase
- `isDisabled = rodadaAtualGlobal <= rodadaDaFase` bloqueava o botão
  da fase atual (ao vivo). Trocado para `<` para permitir clique na
  fase corrente, consistente com `isPending = rodada_atual < rodadaPontosNum`.

BUG 3 (MÉDIO): Invalidar MataMataCache ao reconfigurar wizard
- Ao alterar total_times/qtd_edicoes via wizard, caches antigos
  persistiam com dados de rodadas do calendário anterior.
  Agora deleteMany() limpa o MataMataCache da liga/temporada.

BUG 4 (MÉDIO): Endpoint /edicoes cruza com calendario_efetivo
- Antes: retornava APENAS edições com cache no MongoDB.
  Se consolidação não rodou para ed2, ela não aparecia no dropdown.
- Agora: busca calendario_efetivo da ModuleConfig e retorna TODAS
  as edições configuradas, com flag cache_disponivel para cada uma.

https://claude.ai/code/session_01MZtVgRbg7WaTHQXkEjWbg5