### PR TITLE
fix(mata-mata): auditoria completa — 4 bugs + calendário fixo

### DIFF
--- a/controllers/mata-mata-backend.js
+++ b/controllers/mata-mata-backend.js
@@ -33,11 +33,9 @@ import logger from '../utils/logger.js';
  * Retorna array com id, nome, rodadaInicial, rodadaFinal, rodadaDefinicao.
  */
 function _gerarCalendarioBackend(totalTimes, qtdEdicoes, rodadaFinalCampeonato = 38) {
-    let numFases;
-    if (totalTimes >= 32) numFases = 5;
-    else if (totalTimes >= 16) numFases = 4;
-    else if (totalTimes >= 8) numFases = 3;
-    else return [];
+    const fasesNomes = getFasesParaTamanho(totalTimes);
+    const numFases = fasesNomes.length;
+    if (numFases === 0) return [];
 
     const edicoes = [];
     let rodadaAtual = 2; // Rodada 1 é aquecimento; definição começa na rodada 2
@@ -49,12 +47,19 @@ function _gerarCalendarioBackend(totalTimes, qtdEdicoes, rodadaFinalCampeonato =
 
         if (rodadaFinal > rodadaFinalCampeonato) break;
 
+        // ✅ Mapeamento fixo fase→rodada (fonte de verdade salva no banco)
+        const fases = {};
+        fasesNomes.forEach((fase, idx) => {
+            fases[fase] = rodadaInicial + idx;
+        });
+
         edicoes.push({
             id: i + 1,
             nome: `${i + 1}ª Edição`,
             rodadaInicial,
             rodadaFinal,
-            rodadaDefinicao
+            rodadaDefinicao,
+            fases
         });
 
         rodadaAtual = rodadaFinal + 1;
@@ -893,8 +898,14 @@ export async function calcularBracketParaConsolidacao(ligaId, rodadaAtual) {
             }
 
             const fases = getFasesParaTamanho(tamanhoTorneio);
+            // ✅ Ler mapeamento fixo fase→rodada do calendário salvo no banco
             const rodadasFases = {};
-            fases.forEach((fase, idx) => { rodadasFases[fase] = edicao.rodadaInicial + idx; });
+            if (edicao.fases && typeof edicao.fases === 'object') {
+                Object.assign(rodadasFases, edicao.fases);
+            } else {
+                // Fallback: calcular (retrocompatibilidade com dados antigos)
+                fases.forEach((fase, idx) => { rodadasFases[fase] = edicao.rodadaInicial + idx; });
+            }
 
             // Iniciar com dados existentes do cache (preservar fases já calculadas)
             const dadosTorneio = cacheExistente?.dados_torneio

--- a/public/js/mata-mata/mata-mata-config.js
+++ b/public/js/mata-mata/mata-mata-config.js
@@ -74,12 +74,25 @@ export function getFasesParaTamanho(tamanho) {
   return [];
 }
 
-// Função para obter texto da rodada de pontos (dinâmico por tamanho)
+// ✅ Helper: obter rodada de uma fase — lê do calendário fixo (fases salvas no banco)
+// Fallback: calcula rodadaInicial + idx (para dados antigos sem campo fases)
+export function getRodadaDaFase(edicaoSelecionada, faseKey, tamanhoTorneio) {
+  // Prioridade 1: campo fases salvo no banco (fonte de verdade)
+  if (edicaoSelecionada.fases && edicaoSelecionada.fases[faseKey] != null) {
+    return edicaoSelecionada.fases[faseKey];
+  }
+  // Fallback: calcular dinamicamente (retrocompatibilidade)
+  const fasesArr = getFasesParaTamanho(tamanhoTorneio);
+  const idx = fasesArr.indexOf(faseKey);
+  if (idx === -1) return 0;
+  return edicaoSelecionada.rodadaInicial + idx;
+}
+
+// Função para obter texto da rodada de pontos
 export function getRodadaPontosText(faseLabel, edicao, tamanhoTorneio = TAMANHO_TORNEIO_DEFAULT) {
   const edicaoSelecionada = edicoes.find((e) => e.id === edicao);
   if (!edicaoSelecionada) return "";
 
-  const fases = getFasesParaTamanho(tamanhoTorneio);
   // Mapear label para key
   const labelToKey = {};
   for (const key of Object.keys(FASE_LABELS)) {
@@ -88,22 +101,16 @@ export function getRodadaPontosText(faseLabel, edicao, tamanhoTorneio = TAMANHO_
   const faseKey = labelToKey[faseLabel.toUpperCase()];
   if (!faseKey) return "";
 
-  const idx = fases.indexOf(faseKey);
-  if (idx === -1) return "";
-
-  return `Pontuação da Rodada ${edicaoSelecionada.rodadaInicial + idx}`;
+  const rodada = getRodadaDaFase(edicaoSelecionada, faseKey, tamanhoTorneio);
+  return rodada ? `Pontuação da Rodada ${rodada}` : "";
 }
 
-// Função para obter número da rodada de pontos (dinâmico por tamanho)
+// Função para obter número da rodada de pontos
 export function getRodadaPontosNum(fase, edicao, tamanhoTorneio = TAMANHO_TORNEIO_DEFAULT) {
   const edicaoSelecionada = edicoes.find((e) => e.id === edicao);
   if (!edicaoSelecionada) return 0;
 
-  const fases = getFasesParaTamanho(tamanhoTorneio);
-  const idx = fases.indexOf(fase.toLowerCase());
-  if (idx === -1) return 0;
-
-  return edicaoSelecionada.rodadaInicial + idx;
+  return getRodadaDaFase(edicaoSelecionada, fase.toLowerCase(), tamanhoTorneio);
 }
 
 // Função para obter nome da edição
@@ -125,17 +132,21 @@ export function gerarTextoConfronto(faseLabel) {
   return `Confronto da ${faseLabel}`;
 }
 
-// Função para gerar informações das fases (dinâmico por tamanho)
+// Função para gerar informações das fases — lê do calendário fixo salvo no banco
 export function getFaseInfo(edicaoAtual, edicaoSelecionada, tamanhoTorneio = TAMANHO_TORNEIO_DEFAULT) {
   const fasesAtivas = getFasesParaTamanho(tamanhoTorneio);
   const resultado = {};
 
   fasesAtivas.forEach((fase, idx) => {
+    const rodada = getRodadaDaFase(edicaoSelecionada, fase, tamanhoTorneio);
+    const prevFase = idx > 0 ? fasesAtivas[idx - 1] : null;
+    const prevRodada = prevFase ? getRodadaDaFase(edicaoSelecionada, prevFase, tamanhoTorneio) : null;
+
     resultado[fase] = {
       label: FASE_LABELS[fase],
-      pontosRodada: edicaoSelecionada.rodadaInicial + idx,
+      pontosRodada: rodada,
       numJogos: FASE_NUM_JOGOS[fase],
-      prevFaseRodada: idx > 0 ? edicaoSelecionada.rodadaInicial + idx - 1 : null,
+      prevFaseRodada: prevRodada,
     };
   });
 

--- a/public/js/mata-mata/mata-mata-orquestrador.js
+++ b/public/js/mata-mata/mata-mata-orquestrador.js
@@ -453,7 +453,8 @@ export async function carregarMataMata() {
       const mercadoAberto = data.status_mercado === 1;
       const temporadaAPI = data.temporada || new Date().getFullYear();
       const anoAtual = new Date().getFullYear();
-      const RODADA_FINAL_CAMPEONATO = data.rodada_final || RODADA_FINAL_CAMPEONATO;
+      // ✅ FIX: Usar nome diferente para evitar TDZ (const local não pode referenciar a si mesma)
+      const rodadaFinalCamp = data.rodada_final || RODADA_FINAL_CAMPEONATO;
 
       // v1.4: Detecção dinâmica de temporada com verificação do ano
       if (rodadaAtual === 1 && mercadoAberto) {
@@ -468,7 +469,7 @@ export async function carregarMataMata() {
         }
         // Pré-temporada real: usar rodada 38 da anterior
         console.log("[MATA-ORQUESTRADOR] Pré-temporada - usando rodada 38 da temporada anterior");
-        rodadaAtual = RODADA_FINAL_CAMPEONATO;
+        rodadaAtual = rodadaFinalCamp;
       }
 
       // ✅ Guardar rodada atual global para bloqueio de fases futuras
@@ -814,7 +815,8 @@ function atualizarNavegacaoFases(fasesAtivas) {
       let isDisabled = false;
       if (edicaoSelecionada && rodadaAtualGlobal > 0) {
         const rodadaDaFase = edicaoSelecionada.rodadaInicial + idx;
-        isDisabled = rodadaAtualGlobal <= rodadaDaFase;
+        // ✅ FIX: Usar < (não <=) para permitir clique na fase da rodada atual (ao vivo)
+        isDisabled = rodadaAtualGlobal < rodadaDaFase;
       }
       const disabledClass = isDisabled ? " disabled" : "";
       const lockIcon = isDisabled ? ' 🔒' : '';
@@ -928,7 +930,8 @@ async function carregarFase(fase, ligaId) {
         statusMercadoGlobal = data.status_mercado; // ✅ v2.2: Capturar para detecção isLive
         const temporadaAPI = data.temporada || new Date().getFullYear();
         const anoAtual = new Date().getFullYear();
-        const RODADA_FINAL_CAMPEONATO = data.rodada_final || RODADA_FINAL_CAMPEONATO;
+        // ✅ FIX: Usar nome diferente para evitar TDZ (const local não pode referenciar a si mesma)
+        const rodadaFinalCamp = data.rodada_final || RODADA_FINAL_CAMPEONATO;
 
         // v1.4: Detecção dinâmica de temporada com verificação do ano
         if (rodada_atual === 1 && mercadoAberto) {
@@ -938,7 +941,7 @@ async function carregarFase(fase, ligaId) {
             isTemporadaAnterior = false;
           } else {
             console.log("[MATA-ORQUESTRADOR] Pré-temporada - usando rodada 38 para cálculo de fases");
-            rodada_atual = RODADA_FINAL_CAMPEONATO;
+            rodada_atual = rodadaFinalCamp;
             isTemporadaAnterior = true;
           }
         }

--- a/public/js/mata-mata/mata-mata-orquestrador.js
+++ b/public/js/mata-mata/mata-mata-orquestrador.js
@@ -15,6 +15,7 @@ import {
   getRodadaPontosText,
   getEdicaoMataMata,
   getFasesParaTamanho,
+  getRodadaDaFase,
   TAMANHO_TORNEIO_DEFAULT,
   FASE_LABELS,
   FASE_NUM_JOGOS,
@@ -814,8 +815,8 @@ function atualizarNavegacaoFases(fasesAtivas) {
       // ✅ Verificar se a rodada desta fase já chegou
       let isDisabled = false;
       if (edicaoSelecionada && rodadaAtualGlobal > 0) {
-        const rodadaDaFase = edicaoSelecionada.rodadaInicial + idx;
-        // ✅ FIX: Usar < (não <=) para permitir clique na fase da rodada atual (ao vivo)
+        // ✅ Ler rodada do calendário fixo salvo no banco (não recalcular)
+        const rodadaDaFase = getRodadaDaFase(edicaoSelecionada, fase, tamanhoTorneio);
         isDisabled = rodadaAtualGlobal < rodadaDaFase;
       }
       const disabledClass = isDisabled ? " disabled" : "";

--- a/public/participante/js/modules/participante-mata-mata.js
+++ b/public/participante/js/modules/participante-mata-mata.js
@@ -82,7 +82,8 @@ function getFaseAtual(edicaoId) {
 
   let ultimaLiberada = null;
   for (let idx = 0; idx < fasesAtivas.length; idx++) {
-    if (estado.rodadaAtual >= config.rodadaInicial + idx) {
+    const rodadaDaFase = _getRodadaDaFase(config, fasesAtivas[idx]);
+    if (estado.rodadaAtual >= rodadaDaFase) {
       ultimaLiberada = fasesAtivas[idx];
     }
   }
@@ -356,14 +357,24 @@ function isParciaisAoVivo() {
   return estado.rodadaAtual >= faseAtiva.rodadaInicial && estado.rodadaAtual <= faseAtiva.rodadaPontos;
 }
 
+// ✅ Helper: obter rodada de uma fase — lê do calendário fixo salvo no banco
+// Fallback: calcula rodadaInicial + idx (para dados antigos sem campo fases)
+function _getRodadaDaFase(config, faseKey) {
+  if (config.fases && config.fases[faseKey] != null) {
+    return config.fases[faseKey];
+  }
+  const fasesAtivas = getFasesAtuais();
+  const idx = fasesAtivas.indexOf(faseKey);
+  if (idx < 0) return 0;
+  return config.rodadaInicial + idx;
+}
+
 // Retorna info da rodada de pontos para a fase selecionada
 function getFaseRodada(edicao, fase) {
   const config = EDICOES_MATA_MATA.find(e => e.id === edicao);
   if (!config) return null;
-  const fasesAtivas = getFasesAtuais();
-  const faseIndex = fasesAtivas.indexOf(fase);
-  if (faseIndex < 0) return null;
-  const rodadaPontos = config.rodadaInicial + faseIndex;
+  const rodadaPontos = _getRodadaDaFase(config, fase);
+  if (!rodadaPontos) return null;
   return { rodadaInicial: config.rodadaInicial, rodadaPontos };
 }
 
@@ -810,7 +821,8 @@ function atualizarNavegacaoFases() {
       // ✅ Verificar se a rodada desta fase já chegou
       let isDisabled = false;
       if (edicaoConfig && estado.rodadaAtual > 0) {
-        const rodadaDaFase = edicaoConfig.rodadaInicial + idx;
+        // ✅ Ler rodada do calendário fixo salvo no banco
+        const rodadaDaFase = _getRodadaDaFase(edicaoConfig, fase);
         isDisabled = estado.rodadaAtual < rodadaDaFase;
       }
       const disabledClass = isDisabled ? ' disabled' : '';
@@ -826,7 +838,7 @@ function atualizarNavegacaoFases() {
   // Definir primeira fase como selecionada se não houver ou se está bloqueada
   const fasesLiberadas = fasesAtivas.filter((fase, idx) => {
     if (!edicaoConfig || estado.rodadaAtual <= 0) return true;
-    return estado.rodadaAtual >= edicaoConfig.rodadaInicial + idx;
+    return estado.rodadaAtual >= _getRodadaDaFase(edicaoConfig, fase);
   });
 
   if (!estado.faseSelecionada || !fasesLiberadas.includes(estado.faseSelecionada)) {
@@ -990,9 +1002,11 @@ async function carregarFase(edicao, fase) {
     const fasesAtivas = getFasesAtuais();
     const faseIndex = fasesAtivas.indexOf(fase);
     if (faseIndex >= 0) {
-      const rodadaDaFase = edicaoConfig.rodadaInicial + faseIndex;
+      // ✅ Ler rodada do calendário fixo salvo no banco
+      const rodadaDaFase = _getRodadaDaFase(edicaoConfig, fase);
       if (estado.rodadaAtual <= rodadaDaFase) {
-        const prevRodada = faseIndex > 0 ? edicaoConfig.rodadaInicial + faseIndex - 1 : null;
+        const prevFase = faseIndex > 0 ? fasesAtivas[faseIndex - 1] : null;
+        const prevRodada = prevFase ? _getRodadaDaFase(edicaoConfig, prevFase) : null;
         const faseAnteriorFeita = prevRodada && estado.rodadaAtual > prevRodada;
         if (!faseAnteriorFeita) {
           if (window.Log) Log.info(`[MATA-MATA] 🔒 Fase ${fase} bloqueada - Rodada ${rodadaDaFase} não aconteceu (atual: ${estado.rodadaAtual})`);

--- a/routes/mataMataCacheRoutes.js
+++ b/routes/mataMataCacheRoutes.js
@@ -190,8 +190,18 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
                         fase_atual = "classificacao";
                     } else if (rodadaAtualGlobal >= rodadaInicial && rodadaAtualGlobal <= rodadaFinal) {
                         status_edicao = "em_andamento";
-                        const idxFase = Math.min(rodadaAtualGlobal - rodadaInicial, fasesDoTorneio.length - 1);
-                        fase_atual = fasesDoTorneio[idxFase] || null;
+                        // ✅ Determinar fase atual usando mapeamento fixo do banco
+                        if (cal.fases) {
+                            for (const f of [...fasesDoTorneio].reverse()) {
+                                if (cal.fases[f] && rodadaAtualGlobal >= cal.fases[f]) {
+                                    fase_atual = f;
+                                    break;
+                                }
+                            }
+                        } else {
+                            const idxFase = Math.min(rodadaAtualGlobal - rodadaInicial, fasesDoTorneio.length - 1);
+                            fase_atual = fasesDoTorneio[idxFase] || null;
+                        }
                     } else if (rodadaAtualGlobal > rodadaFinal) {
                         status_edicao = "encerrada";
                         fase_atual = "final";
@@ -201,16 +211,22 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
                 return {
                     edicao: edicaoNum,
                     nome: cal.nome || `${edicaoNum}ª Edição`,
-                    // Calendário completo
+                    // Calendário completo — usa fases salvas no banco (fonte de verdade)
                     calendario: {
                         rodada_definicao: rodadaDefinicao,
                         rodada_inicial: rodadaInicial,
                         rodada_final: rodadaFinal,
-                        fases: fasesDoTorneio.map((f, idx) => ({
-                            fase: f,
-                            label: FASE_LABELS[f],
-                            rodada: rodadaInicial + idx
-                        }))
+                        fases: cal.fases
+                            ? fasesDoTorneio.map(f => ({
+                                fase: f,
+                                label: FASE_LABELS[f],
+                                rodada: cal.fases[f] || (rodadaInicial + fasesDoTorneio.indexOf(f))
+                            }))
+                            : fasesDoTorneio.map((f, idx) => ({
+                                fase: f,
+                                label: FASE_LABELS[f],
+                                rodada: rodadaInicial + idx
+                            }))
                     },
                     // Status atual
                     status_edicao,

--- a/routes/mataMataCacheRoutes.js
+++ b/routes/mataMataCacheRoutes.js
@@ -66,7 +66,9 @@ function validarEdicaoParam(req, res, next) {
 }
 
 // ============================================================================
-// 📋 ROTA PARA LISTAR TODAS AS EDIÇÕES DISPONÍVEIS NO CACHE
+// 📋 ROTA PARA LISTAR TODAS AS EDIÇÕES DISPONÍVEIS
+// ✅ FIX: Cruza MataMataCache com calendario_efetivo da ModuleConfig
+//    para que edições sem cache (ainda não consolidadas) apareçam no dropdown
 // ⚠️ IMPORTANTE: Esta rota DEVE vir ANTES da rota com parâmetro :edicao
 // ============================================================================
 router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
@@ -76,14 +78,15 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
         const temporadaFiltro = temporada ? parseInt(temporada) : CURRENT_SEASON;
 
         console.log(
-            `[MATA-CACHE] 📋 Listando edições disponíveis para liga ${ligaId}, temporada ${temporadaFiltro}`,
+            `[MATA-CACHE] 📋 Listando edições para liga ${ligaId}, temporada ${temporadaFiltro}`,
         );
 
         const MataMataCache = (await import("../models/MataMataCache.js"))
             .default;
+        const ModuleConfig = (await import("../models/ModuleConfig.js")).default;
 
-        // Buscar edições APENAS da temporada especificada
-        const edicoes = await MataMataCache.find({
+        // 1. Buscar edições existentes no cache
+        const edicoesCache = await MataMataCache.find({
             liga_id: ligaId,
             temporada: temporadaFiltro
         })
@@ -91,28 +94,92 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
             .sort({ edicao: 1 })
             .lean();
 
-        if (edicoes.length === 0) {
+        // Mapa de edições com cache para lookup rápido
+        const cacheMap = new Map();
+        edicoesCache.forEach(ed => cacheMap.set(ed.edicao, ed));
+
+        // 2. Buscar calendario_efetivo da ModuleConfig (fonte de verdade do admin)
+        let edicoesCalendario = [];
+        try {
+            const moduleConfig = await ModuleConfig.findOne({
+                liga_id: ligaId,
+                modulo: 'mata_mata',
+                temporada: temporadaFiltro
+            }).lean();
+
+            if (moduleConfig?.calendario_override?.length > 0) {
+                edicoesCalendario = moduleConfig.calendario_override;
+            } else if (moduleConfig?.wizard_respostas?.total_times && moduleConfig?.wizard_respostas?.qtd_edicoes) {
+                // Gerar dinamicamente (mesmo algoritmo de module-config-routes.js)
+                const totalTimes = Number(moduleConfig.wizard_respostas.total_times);
+                const qtdEdicoes = Number(moduleConfig.wizard_respostas.qtd_edicoes);
+                let numFases;
+                if (totalTimes >= 32) numFases = 5;
+                else if (totalTimes >= 16) numFases = 4;
+                else if (totalTimes >= 8) numFases = 3;
+                else numFases = 0;
+
+                if (numFases > 0) {
+                    let rodadaAtual = 2;
+                    for (let i = 0; i < qtdEdicoes; i++) {
+                        const rodadaDefinicao = rodadaAtual;
+                        const rodadaInicial = rodadaDefinicao + 1;
+                        const rodadaFinal = rodadaInicial + numFases - 1;
+                        if (rodadaFinal > 38) break;
+                        edicoesCalendario.push({
+                            edicao: i + 1,
+                            nome: `${i + 1}ª Edição`,
+                            rodada_inicial: rodadaInicial,
+                            rodada_final: rodadaFinal,
+                            rodada_definicao: rodadaDefinicao
+                        });
+                        rodadaAtual = rodadaFinal + 1;
+                    }
+                }
+            }
+        } catch (err) {
+            console.warn(`[MATA-CACHE] ⚠️ Erro ao buscar calendario_efetivo:`, err.message);
+        }
+
+        // 3. Mesclar: todas as edições do calendário, enriquecidas com dados do cache
+        let resumo;
+        if (edicoesCalendario.length > 0) {
+            resumo = edicoesCalendario.map(cal => {
+                const edicaoNum = cal.edicao;
+                const cached = cacheMap.get(edicaoNum);
+                return {
+                    edicao: edicaoNum,
+                    rodada_salva: cached?.rodada_atual || null,
+                    ultima_atualizacao: cached?.ultima_atualizacao || null,
+                    cache_id: cached?._id || null,
+                    cache_disponivel: !!cached,
+                };
+            });
+        } else {
+            // Fallback: retornar apenas edições do cache (sem ModuleConfig)
+            resumo = edicoesCache.map(ed => ({
+                edicao: ed.edicao,
+                rodada_salva: ed.rodada_atual,
+                ultima_atualizacao: ed.ultima_atualizacao,
+                cache_id: ed._id,
+                cache_disponivel: true,
+            }));
+        }
+
+        if (resumo.length === 0) {
             return res.json({
                 liga_id: ligaId,
                 total: 0,
                 edicoes: [],
-                mensagem: "Nenhuma edição encontrada no cache",
+                mensagem: "Nenhuma edição encontrada",
             });
         }
 
-        // Formatar resposta
-        const resumo = edicoes.map((ed) => ({
-            edicao: ed.edicao,
-            rodada_salva: ed.rodada_atual,
-            ultima_atualizacao: ed.ultima_atualizacao,
-            cache_id: ed._id,
-        }));
-
-        console.log(`[MATA-CACHE] ✅ Encontradas ${edicoes.length} edições`);
+        console.log(`[MATA-CACHE] ✅ ${resumo.length} edições (${edicoesCache.length} com cache, ${edicoesCalendario.length} no calendário)`);
 
         res.json({
             liga_id: ligaId,
-            total: edicoes.length,
+            total: resumo.length,
             edicoes: resumo,
         });
     } catch (error) {

--- a/routes/mataMataCacheRoutes.js
+++ b/routes/mataMataCacheRoutes.js
@@ -100,12 +100,14 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
 
         // 2. Buscar calendario_efetivo da ModuleConfig (fonte de verdade do admin)
         let edicoesCalendario = [];
+        let wizardTotalTimes = null;
         try {
             const moduleConfig = await ModuleConfig.findOne({
                 liga_id: ligaId,
                 modulo: 'mata_mata',
                 temporada: temporadaFiltro
             }).lean();
+            wizardTotalTimes = moduleConfig?.wizard_respostas?.total_times ? Number(moduleConfig.wizard_respostas.total_times) : null;
 
             if (moduleConfig?.calendario_override?.length > 0) {
                 edicoesCalendario = moduleConfig.calendario_override;
@@ -141,14 +143,80 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
             console.warn(`[MATA-CACHE] ⚠️ Erro ao buscar calendario_efetivo:`, err.message);
         }
 
-        // 3. Mesclar: todas as edições do calendário, enriquecidas com dados do cache
+        // 3. Determinar rodada atual para calcular fase_atual e status de cada edição
+        let rodadaAtualGlobal = null;
+        try {
+            const cartolaApiService = (await import("../services/cartolaApiService.js")).default;
+            const mercado = await cartolaApiService.obterStatusMercado();
+            rodadaAtualGlobal = mercado?.rodada_atual || mercado?.rodadaAtual || null;
+        } catch (err) {
+            console.warn(`[MATA-CACHE] ⚠️ Não foi possível obter rodada atual:`, err.message);
+        }
+
+        // Helper: calcular fases para tamanho do torneio
+        function getFasesParaTamanho(tamanho) {
+            if (tamanho >= 32) return ["primeira", "oitavas", "quartas", "semis", "final"];
+            if (tamanho >= 16) return ["oitavas", "quartas", "semis", "final"];
+            if (tamanho >= 8) return ["quartas", "semis", "final"];
+            return [];
+        }
+
+        // Determinar tamanho do torneio (reusa wizard_respostas do bloco 2)
+        const tamanhoTorneio = (wizardTotalTimes && [8, 16, 32].includes(wizardTotalTimes)) ? wizardTotalTimes : 32;
+
+        const fasesDoTorneio = getFasesParaTamanho(tamanhoTorneio);
+        const FASE_LABELS = { primeira: "1ª FASE", oitavas: "OITAVAS", quartas: "QUARTAS", semis: "SEMIS", final: "FINAL" };
+
+        // 4. Mesclar: todas as edições do calendário, com calendário + rodada classificação + fase atual
         let resumo;
         if (edicoesCalendario.length > 0) {
             resumo = edicoesCalendario.map(cal => {
                 const edicaoNum = cal.edicao;
                 const cached = cacheMap.get(edicaoNum);
+
+                // Normalizar campos (calendario_override usa snake_case, JSON usa camelCase)
+                const rodadaInicial = cal.rodada_inicial || cal.rodadaInicial;
+                const rodadaFinal = cal.rodada_final || cal.rodadaFinal;
+                const rodadaDefinicao = cal.rodada_definicao || cal.rodadaDefinicao;
+
+                // Calcular fase_atual e status baseado na rodada global
+                let fase_atual = null;
+                let status_edicao = "pendente";
+                if (rodadaAtualGlobal !== null) {
+                    if (rodadaAtualGlobal < rodadaDefinicao) {
+                        status_edicao = "pendente";
+                    } else if (rodadaAtualGlobal === rodadaDefinicao) {
+                        status_edicao = "classificacao";
+                        fase_atual = "classificacao";
+                    } else if (rodadaAtualGlobal >= rodadaInicial && rodadaAtualGlobal <= rodadaFinal) {
+                        status_edicao = "em_andamento";
+                        const idxFase = Math.min(rodadaAtualGlobal - rodadaInicial, fasesDoTorneio.length - 1);
+                        fase_atual = fasesDoTorneio[idxFase] || null;
+                    } else if (rodadaAtualGlobal > rodadaFinal) {
+                        status_edicao = "encerrada";
+                        fase_atual = "final";
+                    }
+                }
+
                 return {
                     edicao: edicaoNum,
+                    nome: cal.nome || `${edicaoNum}ª Edição`,
+                    // Calendário completo
+                    calendario: {
+                        rodada_definicao: rodadaDefinicao,
+                        rodada_inicial: rodadaInicial,
+                        rodada_final: rodadaFinal,
+                        fases: fasesDoTorneio.map((f, idx) => ({
+                            fase: f,
+                            label: FASE_LABELS[f],
+                            rodada: rodadaInicial + idx
+                        }))
+                    },
+                    // Status atual
+                    status_edicao,
+                    fase_atual,
+                    fase_atual_label: fase_atual ? (FASE_LABELS[fase_atual] || fase_atual.toUpperCase()) : null,
+                    // Cache
                     rodada_salva: cached?.rodada_atual || null,
                     ultima_atualizacao: cached?.ultima_atualizacao || null,
                     cache_id: cached?._id || null,
@@ -159,6 +227,11 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
             // Fallback: retornar apenas edições do cache (sem ModuleConfig)
             resumo = edicoesCache.map(ed => ({
                 edicao: ed.edicao,
+                nome: `${ed.edicao}ª Edição`,
+                calendario: null,
+                status_edicao: "desconhecido",
+                fase_atual: null,
+                fase_atual_label: null,
                 rodada_salva: ed.rodada_atual,
                 ultima_atualizacao: ed.ultima_atualizacao,
                 cache_id: ed._id,
@@ -171,15 +244,19 @@ router.get("/cache/:ligaId/edicoes", validarLigaIdParam, async (req, res) => {
                 liga_id: ligaId,
                 total: 0,
                 edicoes: [],
+                rodada_atual: rodadaAtualGlobal,
+                tamanho_torneio: tamanhoTorneio,
                 mensagem: "Nenhuma edição encontrada",
             });
         }
 
-        console.log(`[MATA-CACHE] ✅ ${resumo.length} edições (${edicoesCache.length} com cache, ${edicoesCalendario.length} no calendário)`);
+        console.log(`[MATA-CACHE] ✅ ${resumo.length} edições (${edicoesCache.length} com cache, ${edicoesCalendario.length} no calendário, rodada=${rodadaAtualGlobal})`);
 
         res.json({
             liga_id: ligaId,
             total: resumo.length,
+            rodada_atual: rodadaAtualGlobal,
+            tamanho_torneio: tamanhoTorneio,
             edicoes: resumo,
         });
     } catch (error) {

--- a/routes/module-config-routes.js
+++ b/routes/module-config-routes.js
@@ -556,6 +556,16 @@ router.put('/liga/:ligaId/modulos/:modulo/config', verificarAdmin, async (req, r
                     );
                     console.log(`[MODULE-CONFIG] calendario_override gerado para mata_mata: ${calendarioGerado.length} edições (${wizard_respostas.total_times} times)`);
                 }
+
+                // ✅ FIX: Invalidar MataMataCache ao reconfigurar wizard
+                // Caches antigos podem ter dados baseados em rodadas de calendário anterior
+                const MataMataCache = (await import('../models/MataMataCache.js')).default;
+                const ligaIdQuery = mongoose.Types.ObjectId.isValid(ligaId) ? new mongoose.Types.ObjectId(ligaId) : ligaId;
+                const mmDeleted = await MataMataCache.deleteMany({
+                    liga_id: String(ligaIdQuery),
+                    temporada: Number(temporada)
+                });
+                console.log(`[MODULE-CONFIG] MataMataCache invalidado para liga ${ligaId}: ${mmDeleted.deletedCount} entradas removidas`);
             }
 
             // ✅ v11.0: Invalidar cache do melhor_mes quando edições são reconfiguradas

--- a/routes/module-config-routes.js
+++ b/routes/module-config-routes.js
@@ -32,17 +32,22 @@ const router = express.Router();
  * @param {number} rodadaFinalCampeonato - Última rodada do campeonato (default: 38)
  * @returns {Array} Array de edições com rodada_inicial, rodada_final, rodada_definicao
  */
+/**
+ * Retorna nomes das fases para o tamanho do torneio.
+ */
+function getFasesParaTamanho(totalTimes) {
+    if (totalTimes >= 32) return ['primeira', 'oitavas', 'quartas', 'semis', 'final'];
+    if (totalTimes >= 16) return ['oitavas', 'quartas', 'semis', 'final'];
+    if (totalTimes >= 8)  return ['quartas', 'semis', 'final'];
+    return [];
+}
+
 function gerarCalendarioMataMata(totalTimes, qtdEdicoes, rodadaFinalCampeonato = 38) {
-    // Calcular número de fases baseado no tamanho do torneio
-    let numFases;
-    if (totalTimes >= 32) numFases = 5; // primeira, oitavas, quartas, semis, final
-    else if (totalTimes >= 16) numFases = 4; // oitavas, quartas, semis, final
-    else if (totalTimes >= 8) numFases = 3; // quartas, semis, final
-    else return [];
+    const fasesNomes = getFasesParaTamanho(totalTimes);
+    const numFases = fasesNomes.length;
+    if (numFases === 0) return [];
 
     // Cada edição precisa: 1 rodada de definição + N rodadas de fases
-    // Espaçamento: sem gap entre edições (consistente com o JSON original onde
-    // rodadaDefinicao da próxima = rodadaFinal da anterior, ex: ed4 final=R26, ed5 def=R26)
     const calendario = [];
     let rodadaAtual = 2; // Rodada 1 é aquecimento; definição começa na rodada 2
 
@@ -57,12 +62,19 @@ function gerarCalendarioMataMata(totalTimes, qtdEdicoes, rodadaFinalCampeonato =
             break;
         }
 
+        // ✅ Mapeamento fixo fase→rodada (salvo no banco como fonte de verdade)
+        const fases = {};
+        fasesNomes.forEach((fase, idx) => {
+            fases[fase] = rodadaInicial + idx;
+        });
+
         calendario.push({
             edicao: i + 1,
             nome: `${i + 1}ª Edição`,
             rodada_inicial: rodadaInicial,
             rodada_final: rodadaFinal,
-            rodada_definicao: rodadaDefinicao
+            rodada_definicao: rodadaDefinicao,
+            fases
         });
 
         // Próxima edição: definição começa na rodada seguinte ao final
@@ -304,7 +316,8 @@ router.get('/liga/:ligaId/modulos/:modulo', async (req, res) => {
                 nome: e.nome,
                 rodadaInicial: e.rodada_inicial,
                 rodadaFinal: e.rodada_final,
-                rodadaDefinicao: e.rodada_definicao
+                rodadaDefinicao: e.rodada_definicao,
+                fases: e.fases || null  // ✅ Mapeamento fixo fase→rodada salvo no banco
             }));
         } else if (modulo === 'mata_mata' && configDb?.wizard_respostas?.total_times && configDb?.wizard_respostas?.qtd_edicoes) {
             // Gerar dinamicamente quando calendario_override está vazio mas wizard foi configurado
@@ -318,7 +331,8 @@ router.get('/liga/:ligaId/modulos/:modulo', async (req, res) => {
                     nome: e.nome,
                     rodadaInicial: e.rodada_inicial,
                     rodadaFinal: e.rodada_final,
-                    rodadaDefinicao: e.rodada_definicao
+                    rodadaDefinicao: e.rodada_definicao,
+                    fases: e.fases || null  // ✅ Mapeamento fixo fase→rodada
                 }));
                 console.log(`[MODULE-CONFIG] calendario_efetivo gerado de wizard_respostas: ${gerado.length} edições (${configDb.wizard_respostas.total_times} times)`);
             }


### PR DESCRIPTION
## Summary

Auditoria completa do módulo MataMata — corrige 4 bugs e implementa calendário fixo com mapeamento fase→rodada salvo no banco.

### Bugs Corrigidos

- **BUG 1 (CRÍTICO):** TDZ crash latente — `const RODADA_FINAL_CAMPEONATO = data.rodada_final || RODADA_FINAL_CAMPEONATO` referenciava a própria const em temporal dead zone. Renomeado para `rodadaFinalCamp`
- **BUG 2 (ALTO):** Off-by-one no bloqueio de botões de fase — `<=` trocado por `<` para permitir clique na fase da rodada atual (ao vivo)
- **BUG 3 (MÉDIO):** Cache stale ao reconfigurar wizard — agora `deleteMany()` limpa MataMataCache da liga ao alterar total_times/qtd_edicoes
- **BUG 4 (MÉDIO):** Edição invisível no app participante — endpoint `/edicoes` agora cruza com `calendario_efetivo` da ModuleConfig, retornando TODAS as edições configuradas (não apenas as que têm cache)

### Calendário Fixo (causa raiz)

O sistema calculava `rodadaDaFase = rodadaInicial + faseIndex` dinamicamente em 4+ locais independentes. Sem tabela fixa no banco, qualquer reconfig gerava divergência.

- Campo `fases` do `calendario_override` (já existia no schema, nunca era populado) agora recebe `{primeira: 3, oitavas: 4, quartas: 5, semis: 6, final: 7}`
- Todos os consumidores leem do banco via `getRodadaDaFase()` com fallback para cálculo dinâmico (retrocompatibilidade)

### Endpoint `/edicoes` Enriquecido

Resposta agora inclui: `calendario` (rodada_definicao, rodada_inicial, rodada_final, fases[]), `status_edicao` (pendente/classificacao/em_andamento/encerrada), `fase_atual`, `rodada_atual`, `tamanho_torneio`

### Arquivos (6)

- `controllers/mata-mata-backend.js`
- `public/js/mata-mata/mata-mata-config.js`
- `public/js/mata-mata/mata-mata-orquestrador.js`
- `public/participante/js/modules/participante-mata-mata.js`
- `routes/mataMataCacheRoutes.js`
- `routes/module-config-routes.js`

## Test plan

- [ ] Reconfigurar MataMata via wizard → verificar que `calendario_override` salvo inclui campo `fases`
- [ ] Admin → MataMata → verificar que rodada de cada fase vem do calendário fixo
- [ ] App participante → verificar que edição 2 aparece no dropdown e fases usam mesmas rodadas
- [ ] Testar com 8, 16 e 32 times → fases correspondem ao tamanho
- [ ] Testar cenário API sem `rodada_final` → sem crash (fix TDZ)
- [ ] Verificar que botão da fase atual (ao vivo) está habilitado

https://claude.ai/code/session_01MZtVgRbg7WaTHQXkEjWbg5