### PR TITLE
fix(top10): adicionar campo `pontos` nos mitos/micos para splash screen

### DIFF
--- a/controllers/consolidacaoController.js
+++ b/controllers/consolidacaoController.js
@@ -357,6 +357,7 @@ export const consolidarRodada = async (req, res) => {
 
         const mitos = rankingRodada.slice(0, 10).map((t, i) => ({
             ...t,
+            pontos: t.pontos_rodada,
             premio: configTop10.mitos[i + 1] || configTop10.mitos[String(i + 1)] || 0
         }));
 
@@ -365,6 +366,7 @@ export const consolidarRodada = async (req, res) => {
             .slice(0, 10)
             .map((t, i) => ({
                 ...t,
+                pontos: t.pontos_rodada,
                 posicao: rankingRodada.length - i,
                 multa: configTop10.micos[i + 1] || configTop10.micos[String(i + 1)] || 0
             }));

--- a/services/notificationTriggers.js
+++ b/services/notificationTriggers.js
@@ -172,7 +172,7 @@ export async function triggerMitoMico(ligaId, rodadaNum, top10Data) {
 
         const payloadMito = {
           title: '🏆 VOCE E O MITO DA RODADA!',
-          body: `Parabens! Voce fez ${formatarPontos(mito.pontos_rodada)} pontos na R${rodadaNum}${premioText}`,
+          body: `Parabens! Voce fez ${formatarPontos(mito.pontos)} pontos na R${rodadaNum}${premioText}`,
           url: '/participante/rodadas',
           tag: `mito-${rodadaNum}`,
           icon: '/participante/icons/icon-192x192.png',
@@ -181,7 +181,7 @@ export async function triggerMitoMico(ligaId, rodadaNum, top10Data) {
             tipo: 'mito',
             ligaId,
             rodada: rodadaNum,
-            pontos: mito.pontos_rodada,
+            pontos: mito.pontos,
             premio: mito.premio || 0,
             timestamp: Date.now()
           }
@@ -210,7 +210,7 @@ export async function triggerMitoMico(ligaId, rodadaNum, top10Data) {
 
         const payloadMico = {
           title: '😬 Voce foi o Mico da Rodada',
-          body: `Voce fez ${formatarPontos(mico.pontos_rodada)} pontos na R${rodadaNum}.${multaText}`,
+          body: `Voce fez ${formatarPontos(mico.pontos)} pontos na R${rodadaNum}.${multaText}`,
           url: '/participante/rodadas',
           tag: `mico-${rodadaNum}`,
           icon: '/participante/icons/icon-192x192.png',
@@ -219,7 +219,7 @@ export async function triggerMitoMico(ligaId, rodadaNum, top10Data) {
             tipo: 'mico',
             ligaId,
             rodada: rodadaNum,
-            pontos: mico.pontos_rodada,
+            pontos: mico.pontos,
             multa: mico.multa || 0,
             timestamp: Date.now()
           }


### PR DESCRIPTION
O consolidacaoController criava mitos/micos com campo `pontos_rodada`
via spread, mas o schema Top10Cache e o frontend (participante-mito-mico-modal)
esperam campo `pontos`. Resultado: splash exibia "0.00 pts".

Adiciona `pontos: t.pontos_rodada` no map de mitos e micos.
Rodadas já consolidadas precisam ser reconsolidadas para corrigir dados existentes.

https://claude.ai/code/session_01NschFeZXcD2m45hMQoAkdV