### PR TITLE
fix(top10): retornar todos participantes por rodada no endpoint /api/ligas/:id/top10

### DIFF
--- a/routes/ligas.js
+++ b/routes/ligas.js
@@ -669,7 +669,6 @@ router.get("/:id/top10", async (req, res) => {
         .sort(
           (a, b) => (parseFloat(b.pontos) || 0) - (parseFloat(a.pontos) || 0),
         )
-        .slice(0, 10)
         .map((time, index) => ({
           posicao: index + 1,
           timeId: time.timeId,


### PR DESCRIPTION
O .slice(0, 10) cortava os dados para apenas os 10 melhores de cada rodada,
impossibilitando o frontend de calcular o MICO (pior pontuador). O "mico"
exibido era o 10º melhor ao invés do último colocado.

https://claude.ai/code/session_01JHVfoXHhLGnnXW3F1TkwCL