### PR TITLE
fix(pontos-corridos): detectar bracket desatualizado ao adicionar participante

### DIFF
--- a/controllers/pontosCorridosCacheController.js
+++ b/controllers/pontosCorridosCacheController.js
@@ -529,7 +529,18 @@ async function calcularRodadaComParciais(
         // PRIORIDADE 1: Usar bracket extraído do cache salvo pelo admin (fonte da verdade absoluta).
         // PRIORIDADE 2: Fallback para liga.participantes APENAS se não há nenhum cache anterior.
         let jogosDaRodada;
-        const listaIdsDoCache = extrairOrdemDoCache(dadosExistentes);
+        let listaIdsDoCache = extrairOrdemDoCache(dadosExistentes);
+
+        // ✅ Detecção de divergência: participante adicionado após bracket gerado
+        if (listaIdsDoCache) {
+            const idsAtivos = new Set(times.filter(t => t.ativo !== false).map(t => String(t.time_id)));
+            const idsDoBracket = new Set(listaIdsDoCache.map(String));
+            const ausentes = [...idsAtivos].filter(id => !idsDoBracket.has(id));
+            if (ausentes.length > 0) {
+                logger.warn(`[PONTOS-CORRIDOS] ⚠️ BRACKET DESATUALIZADO: ${ausentes.length} participante(s) ativo(s) ausente(s) no bracket cacheado. IDs: [${ausentes.join(', ')}]. Forçando regeneração a partir de liga.participantes.`);
+                listaIdsDoCache = null; // Invalida cache → fallback para gerarConfrontos
+            }
+        }
 
         if (listaIdsDoCache) {
             // ✅ Usa o bracket do admin — garante que os confrontos do app = confrontos do admin
@@ -751,9 +762,20 @@ async function reconstruirCacheDeRodadas(ligaId, temporada, config, timesMap) {
             .sort({ rodada_consolidada: 1 })
             .lean();
 
-        const listaIdsDoCache = extrairOrdemDoCache(
+        let listaIdsDoCache = extrairOrdemDoCache(
             cachesExistentes.map(c => ({ rodada: c.rodada_consolidada, confrontos: c.confrontos }))
         );
+
+        // ✅ Detecção de divergência: participante adicionado após bracket gerado
+        if (listaIdsDoCache) {
+            const idsAtivos = new Set(times.filter(t => t.ativo !== false).map(t => String(t.time_id)));
+            const idsDoBracket = new Set(listaIdsDoCache.map(String));
+            const ausentes = [...idsAtivos].filter(id => !idsDoBracket.has(id));
+            if (ausentes.length > 0) {
+                logger.warn(`[PONTOS-CORRIDOS] ⚠️ BRACKET DESATUALIZADO (reconstrução): ${ausentes.length} participante(s) ausente(s). IDs: [${ausentes.join(', ')}]. Forçando regeneração.`);
+                listaIdsDoCache = null;
+            }
+        }
 
         let confrontosBase;
         if (listaIdsDoCache) {


### PR DESCRIPTION
## Summary

- Adiciona detecção de divergência entre participantes ativos da liga e IDs do bracket cacheado
- Quando um time é adicionado após o bracket já ter sido gerado, o sistema agora detecta a ausência e invalida o cache antigo, forçando regeneração com todos os participantes
- Corrige anomalia onde "RB Ousadia&Alegria 94" ficava com 0 jogos na classificação porque foi adicionado após o bracket de 34 times já estar cacheado

### Causa raiz
`extrairOrdemDoCache()` extraía IDs apenas dos caches existentes (34 times). O 35º time nunca entrava no bracket → 0 jogos. Os outros 34 tinham 8 jogos iguais (sem BYE, pois 34 é par).

### Alterações
- `calcularRodadaComParciais()` — detecção de divergência após `extrairOrdemDoCache()`
- `reconstruirHistoricoCompleto()` — mesma detecção

### Ação pós-merge (obrigatória)
Na VPS, rodar o script de regeneração para corrigir os caches existentes:
```bash
cd /var/www/cartola
node scripts/regenerar-bracket-pontos-corridos.js --all --dry-run
node scripts/regenerar-bracket-pontos-corridos.js --liga-id <LIGA_ID> --force
```

## Test plan
- [ ] Verificar que na próxima rodada, o sistema detecta a divergência e gera bracket com 35 times
- [ ] Rodar script de regeneração na VPS para corrigir dados históricos
- [ ] Confirmar que RB Ousadia&Alegria 94 passa a ter jogos na classificação
- [ ] Confirmar que os 35 times têm contagem de jogos variada (BYE rotacionando)

https://claude.ai/code/session_019Xu6k5ViYvXqkHcVdCP3BN