### PR TITLE
fix: corrigir título 'Rodada X' e melhorar UX de erro no calendário

### DIFF
--- a/public/participante/fronts/rodadas.html
+++ b/public/participante/fronts/rodadas.html
@@ -2440,7 +2440,7 @@
     <div id="rodadaDetalhamento" class="rodada-detalhamento-pro" style="display: none;">
         <div class="detalhamento-header-pro">
             <div class="detalhamento-info">
-                <h3 id="rodadaTitulo">Rodada X</h3>
+                <h3 id="rodadaTitulo">Rodada</h3>
                 <p id="rodadaResumo" class="rodada-resumo"></p>
                 <div id="autoRefreshIndicator" class="auto-refresh-indicator" style="display: none;">
                     <span class="material-symbols-outlined">autorenew</span>

--- a/public/participante/js/modules/participante-rodadas.js
+++ b/public/participante/js/modules/participante-rodadas.js
@@ -1328,6 +1328,43 @@ async function selecionarRodada(numeroRodada, isParcial = false) {
                 },
                 onStatus: atualizarIndicadorAutoRefresh
             });
+        } else if (numeroRodada === rodadaAtualCartola && statusMercadoAtual === 2) {
+            // ✅ FIX: Rodada ao vivo mas parciais não inicializou — tentar agora
+            if (window.Log) Log.warn(`[PARTICIPANTE-RODADAS] ⚠️ Rodada ${numeroRodada} ao vivo mas parciaisInfo indisponível — tentando fallback`);
+            try {
+                await carregarERenderizarParciais(numeroRodada);
+
+                // Atualizar parciaisInfo para que próximos clicks não precisem do fallback
+                parciaisInfo = { disponivel: true, rodada: numeroRodada, bolaRolando: true };
+
+                // Iniciar polling normalmente
+                PollingInteligenteModule.inicializar({
+                    temporada: TEMPORADA_ATUAL,
+                    rodada: numeroRodada,
+                    ligaId: ligaId,
+                    timeId: meuTimeId,
+                    onUpdate: (dados) => {
+                        if (rodadaSelecionada !== numeroRodada) return;
+                        renderizarParciaisDados(numeroRodada, dados);
+                    },
+                    onStatus: atualizarIndicadorAutoRefresh
+                });
+            } catch (parcErr) {
+                if (window.Log) Log.error(`[PARTICIPANTE-RODADAS] ❌ Fallback de parciais falhou:`, parcErr);
+                if (rankingContainer) {
+                    rankingContainer.innerHTML = `
+                        <div style="text-align: center; padding: 40px; color: var(--app-danger);">
+                            <span class="material-icons" style="font-size: 48px; margin-bottom: 16px;">sync_problem</span>
+                            <p>Parciais temporariamente indisponíveis</p>
+                            <p style="color: var(--app-text-muted); font-size: 0.85rem; margin-top: 8px;">A rodada está ao vivo mas não foi possível carregar as pontuações</p>
+                            <button onclick="selecionarRodada(${numeroRodada}, true)"
+                                    style="margin-top: 16px; padding: 10px 20px; background: var(--app-primary); color: white; border: none; border-radius: 8px; cursor: pointer;">
+                                Tentar Novamente
+                            </button>
+                        </div>
+                    `;
+                }
+            }
         } else {
             const rodadaData = todasRodadasCache.find((r) => r.numero === numeroRodada);
             if (window.Log)

--- a/public/participante/js/modules/participante-rodadas.js
+++ b/public/participante/js/modules/participante-rodadas.js
@@ -1286,6 +1286,11 @@ async function selecionarRodada(numeroRodada, isParcial = false) {
         Log.info(`[PARTICIPANTE-RODADAS] 📊 Cache: ${todasRodadasCache.length} rodadas em cache`);
 
     rodadaSelecionada = numeroRodada;
+
+    // ✅ FIX: Atualizar título EAGERLY — garante "Rodada N" em TODOS os paths (sucesso e erro)
+    const tituloEl = document.getElementById("rodadaTitulo");
+    if (tituloEl) tituloEl.textContent = `Rodada ${numeroRodada}`;
+
     ParciaisModule.pararAutoRefresh?.();
     PollingInteligenteModule.parar?.();
     atualizarIndicadorAutoRefresh({ ativo: false });
@@ -1300,7 +1305,7 @@ async function selecionarRodada(numeroRodada, isParcial = false) {
         rankingContainer.innerHTML = `
             <div style="text-align: center; padding: 40px;">
                 <div class="loading-spinner-rodadas"></div>
-                <p style="color: #9ca3af; margin-top: 16px;">Carregando...</p>
+                <p style="color: var(--app-text-muted); margin-top: 16px;">Carregando...</p>
             </div>
         `;
     }
@@ -1353,9 +1358,13 @@ async function selecionarRodada(numeroRodada, isParcial = false) {
 
                 if (rankingContainer) {
                     rankingContainer.innerHTML = `
-                        <div style="text-align: center; padding: 40px; color: #6b7280;">
+                        <div style="text-align: center; padding: 40px; color: var(--app-text-muted);">
                             <span class="material-icons" style="font-size: 48px; margin-bottom: 16px;">inbox</span>
                             <p>Dados desta rodada não disponíveis</p>
+                            <button onclick="selecionarRodada(${numeroRodada}, false)"
+                                    style="margin-top: 16px; padding: 10px 20px; background: var(--app-primary); color: white; border: none; border-radius: 8px; cursor: pointer;">
+                                Tentar Novamente
+                            </button>
                         </div>
                     `;
                 }
@@ -1413,7 +1422,7 @@ async function carregarERenderizarParciais(numeroRodada) {
                     <span class="material-icons" style="font-size: 48px; margin-bottom: 16px;">error_outline</span>
                     <p>Erro ao carregar parciais</p>
                     <button onclick="selecionarRodada(${numeroRodada}, true)"
-                            style="margin-top: 16px; padding: 10px 20px; background: #E65100; color: white; border: none; border-radius: 8px; cursor: pointer;">
+                            style="margin-top: 16px; padding: 10px 20px; background: var(--app-primary); color: white; border: none; border-radius: 8px; cursor: pointer;">
                         Tentar Novamente
                     </button>
                 </div>


### PR DESCRIPTION
- Setar título eagerly no início de selecionarRodada() para garantir
  'Rodada N' em todos os paths (sucesso e erro)
- Adicionar botão 'Tentar Novamente' no erro de dados não disponíveis
- Substituir cores hardcoded (#6b7280, #9ca3af, #E65100) por variáveis
  CSS (--app-text-muted, --app-primary)
- Atualizar placeholder HTML de 'Rodada X' para 'Rodada'

https://claude.ai/code/session_019hWEmRvGC9BFqYs1BJ6aHm