### PR TITLE
fix: totalAtletas conta apenas titulares, não soma reservas

### DIFF
--- a/controllers/parciaisController.js
+++ b/controllers/parciaisController.js
@@ -242,8 +242,7 @@ function calcularPontuacao(dadosEscalacao, atletasPontuados, time) {
     }
   }
 
-  const totalAtletas =
-    (dadosEscalacao.atletas?.length || 0) + (dadosEscalacao.reservas?.length || 0);
+  const totalAtletas = dadosEscalacao.atletas?.length || 0;
 
   return {
     timeId: time.timeId,

--- a/services/parciaisRankingService.js
+++ b/services/parciaisRankingService.js
@@ -135,7 +135,7 @@ function calcularPontuacaoTime(escalacao, atletasPontuados) {
     let atletasEmCampo = 0;
     const capitaoId = escalacao.capitao_id;
     const reservaLuxoId = escalacao.reserva_luxo_id;
-    const totalAtletas = (escalacao.atletas?.length || 0) + (escalacao.reservas?.length || 0);
+    const totalAtletas = escalacao.atletas?.length || 0;
 
     // ── FASE 1: Titulares ──
     const titularesProcessados = [];


### PR DESCRIPTION
Reservas são substitutos que ocupam a vaga de um titular ausente,
não jogadores adicionais. O denominador do indicador "X/Y em campo"
agora reflete corretamente o tamanho da escalação (12), não o
total do elenco (12+5=17).

https://claude.ai/code/session_01E3UNtEwN5UQk24SiLMVcPc