### PR TITLE
fix(brasileirao): corrigir classificação e rodadas com replaceMode + refresh real

### DIFF
--- a/models/CalendarioBrasileirao.js
+++ b/models/CalendarioBrasileirao.js
@@ -451,11 +451,98 @@ calendarioBrasileiraoSchema.statics.obterOuCriar = async function(temporada) {
  * Semáforo simples para prevenir race condition entre syncs simultâneos
  */
 let _importLock = false;
-calendarioBrasileiraoSchema.statics.importarPartidas = async function(temporada, partidasNovas, fonte) {
+calendarioBrasileiraoSchema.statics.importarPartidas = async function(temporada, partidasNovas, fonte, options = {}) {
     if (_importLock) throw new Error('importarPartidas já em andamento — aguarde conclusão');
     _importLock = true;
     try {
+    const { replaceMode = false } = options;
     const calendario = await this.obterOuCriar(temporada);
+
+    // ── REPLACE MODE ──────────────────────────────────────────────
+    // Substitui TODAS as partidas pelo array novo (remove lixo de seed/syncs antigos).
+    // Preserva data_original/horario_original/rodada_original de partidas existentes
+    // para manter tracking de remarcações.
+    if (replaceMode) {
+        // Mapa de partidas existentes: chave = mandante_id-visitante_id
+        const existentesMap = new Map();
+        for (const p of calendario.partidas) {
+            if (p.mandante_id && p.visitante_id) {
+                const obj = p.toObject ? p.toObject() : p;
+                existentesMap.set(`${p.mandante_id}-${p.visitante_id}`, obj);
+            }
+        }
+
+        const novasPartidas = [];
+        for (const nova of partidasNovas) {
+            const chave = (nova.mandante_id && nova.visitante_id)
+                ? `${nova.mandante_id}-${nova.visitante_id}`
+                : null;
+            const existente = chave ? existentesMap.get(chave) : null;
+
+            if (existente) {
+                // Detectar remarcação comparando existente vs novo
+                const statusAtivo = existente.status !== 'encerrado' && existente.status !== 'cancelado';
+                const dataMudou = nova.data && nova.data !== existente.data;
+                const horarioMudou = nova.horario && nova.horario !== existente.horario && nova.horario !== '00:00';
+
+                if (statusAtivo && (dataMudou || horarioMudou)) {
+                    if (!calendario.remarcacoes) calendario.remarcacoes = [];
+                    calendario.remarcacoes.push({
+                        mandante_id: existente.mandante_id,
+                        visitante_id: existente.visitante_id,
+                        mandante: existente.mandante,
+                        visitante: existente.visitante,
+                        rodada_original: existente.rodada_original || existente.rodada,
+                        data_original: existente.data_original || existente.data,
+                        horario_original: existente.horario_original || existente.horario,
+                        data_nova: nova.data,
+                        horario_novo: nova.horario,
+                        rodada_nova: nova.rodada,
+                        detectado_em: new Date(),
+                        fonte,
+                        resolvido: false,
+                        resolvido_em: null,
+                    });
+                }
+
+                // Resolver remarcações pendentes se jogo encerrou
+                if (nova.status === 'encerrado' && calendario.remarcacoes?.length > 0) {
+                    const rodadaFinal = (nova.rodada >= 1 && nova.rodada <= 38) ? nova.rodada : existente.rodada;
+                    for (const rem of calendario.remarcacoes) {
+                        if (rem.resolvido) continue;
+                        if (rem.mandante_id === existente.mandante_id && rem.visitante_id === existente.visitante_id) {
+                            if (rodadaFinal === rem.rodada_original) {
+                                rem.resolvido = true;
+                                rem.resolvido_em = new Date();
+                            }
+                        }
+                    }
+                }
+
+                // Montar partida preservando originais do existente
+                novasPartidas.push({
+                    ...nova,
+                    data_original: existente.data_original || existente.data,
+                    horario_original: existente.horario_original || existente.horario,
+                    rodada_original: existente.rodada_original || existente.rodada,
+                });
+            } else {
+                // Partida totalmente nova
+                novasPartidas.push({
+                    ...nova,
+                    data_original: nova.data,
+                    horario_original: nova.horario,
+                    rodada_original: nova.rodada,
+                });
+            }
+        }
+
+        // Substituir array inteiro — elimina todo lixo de seeds/syncs antigos
+        calendario.partidas = novasPartidas;
+        console.log(`[BRASILEIRAO] replaceMode: ${novasPartidas.length} partidas (anterior: ${existentesMap.size})`);
+
+    } else {
+    // ── MERGE MODE (comportamento original) ───────────────────────
 
     for (const nova of partidasNovas) {
         // v1.1: Match primário por mandante_id + visitante_id (mais robusto que rodada + nomes).
@@ -485,14 +572,11 @@ calendarioBrasileiraoSchema.statics.importarPartidas = async function(temporada,
             const existenteObj = existente.toObject ? existente.toObject() : existente;
 
             // ── DETECÇÃO DE REMARCAÇÃO ─────────────────────────────────
-            // Comparar data/horario novos com existentes.
-            // Só detecta se o jogo ainda não aconteceu (não encerrado/cancelado).
             const statusAtivo = existenteObj.status !== 'encerrado' && existenteObj.status !== 'cancelado';
             const dataExistente = existenteObj.data;
             const horarioExistente = existenteObj.horario;
             const dataMudou = nova.data && nova.data !== dataExistente;
             const horarioMudou = nova.horario && nova.horario !== horarioExistente && nova.horario !== '00:00';
-            const rodadaMudou = nova.rodada >= 1 && nova.rodada <= 38 && nova.rodada !== existenteObj.rodada;
 
             if (statusAtivo && (dataMudou || horarioMudou)) {
                 const remarcacao = {
@@ -517,7 +601,6 @@ calendarioBrasileiraoSchema.statics.importarPartidas = async function(temporada,
             }
 
             // ── RESOLUÇÃO DE REMARCAÇÃO ───────────────────────────────
-            // Se jogo virou encerrado E está na rodada original → resolver remarcações pendentes
             if (nova.status === 'encerrado' && calendario.remarcacoes?.length > 0) {
                 const rodadaFinal = (nova.rodada >= 1 && nova.rodada <= 38) ? nova.rodada : existenteObj.rodada;
                 for (const rem of calendario.remarcacoes) {
@@ -528,7 +611,6 @@ calendarioBrasileiraoSchema.statics.importarPartidas = async function(temporada,
                             rem.resolvido_em = new Date();
                             console.log(`[BRASILEIRAO] ✅ Remarcação resolvida: ${existenteObj.mandante} x ${existenteObj.visitante} (jogou na R${rodadaFinal})`);
                         }
-                        // Se rodada diferente: permanece resolvido=false como histórico permanente
                     }
                 }
             }
@@ -541,12 +623,9 @@ calendarioBrasileiraoSchema.statics.importarPartidas = async function(temporada,
             calendario.partidas[idx] = {
                 ...existenteObj,
                 ...nova,
-                // Preservar IDs do Cartola se já temos
                 mandante_id: nova.mandante_id || existente.mandante_id,
                 visitante_id: nova.visitante_id || existente.visitante_id,
-                // Preservar rodada do MongoDB se nova é 0 (inferência falhou)
                 rodada: rodadaFinal,
-                // Definir data_original/horario_original/rodada_original apenas no primeiro sync
                 data_original: existenteObj.data_original || dataExistente,
                 horario_original: existenteObj.horario_original || horarioExistente,
                 rodada_original: existenteObj.rodada_original || existenteObj.rodada,
@@ -561,6 +640,8 @@ calendarioBrasileiraoSchema.statics.importarPartidas = async function(temporada,
             });
         }
     }
+
+    } // fim merge mode
 
     calendario.ultima_atualizacao = new Date();
     calendario.fonte = fonte;

--- a/public/participante/js/modules/participante-brasileirao.js
+++ b/public/participante/js/modules/participante-brasileirao.js
@@ -81,11 +81,11 @@ function escapeHtml(str) {
         .replace(/"/g, '&quot;');
 }
 
-async function _fetchComTimeout(url) {
+async function _fetchComTimeout(url, opts = {}) {
     const controller = new AbortController();
     const t = setTimeout(() => controller.abort(), _FETCH_TIMEOUT_MS);
     try {
-        const res = await fetch(url, { signal: controller.signal });
+        const res = await fetch(url, { ...opts, signal: controller.signal });
         clearTimeout(t);
         return res;
     } catch (err) {
@@ -536,6 +536,38 @@ function _setupRefreshButton() {
         fresh.disabled = true;
         icon.classList.add('spinning');
         try {
+            // Rebuscar tudo das fontes externas (API-Football → ESPN)
+            // O /refresh força sync real — não lê apenas cache
+            const temporada = _temporadaAtual || new Date().getFullYear();
+            const refreshRes = await _fetchComTimeout(`/api/brasileirao/refresh/${temporada}`, { method: 'POST' });
+
+            if (refreshRes.ok) {
+                const data = await refreshRes.json();
+                if (data.success) {
+                    // Dados frescos do refresh — renderizar direto
+                    if (data.rodada_atual) {
+                        _rodadaAtualRef = data.rodada_atual;
+                        _rodadaExibida = data.rodada_atual;
+                    }
+                    _renderizarClassificacao({
+                        classificacao: data.classificacao,
+                        rodada_atual: data.rodada_atual,
+                        success: true,
+                    });
+                    _renderizarJogosRodada({
+                        jogos_rodada_atual: data.jogos_rodada_atual,
+                        rodada_atual: data.rodada_atual,
+                        success: true,
+                    });
+                    _ultimaAtualizacao = Date.now();
+                    _atualizarStatus();
+                    if (window.Log) Log.info('BRASILEIRAO-LP', `Refresh: ${data.jogosImportados} jogos via ${data.fonte}`);
+                    return;
+                }
+            }
+
+            // Fallback: se refresh falhou (rate limit, erro), ler do cache normalmente
+            if (window.Log) Log.warn('BRASILEIRAO-LP', 'Refresh falhou, usando cache');
             const [apiClassificacao, apiResumo] = await Promise.all([
                 _carregarClassificacao(),
                 _carregarResumo(),

--- a/routes/brasileirao-tabela-routes.js
+++ b/routes/brasileirao-tabela-routes.js
@@ -200,6 +200,73 @@ router.get('/classificacao/:temporada', async (req, res) => {
     }
 });
 
+/**
+ * POST /api/brasileirao/refresh/:temporada
+ * Rebusca dados das fontes externas (API-Football → ESPN), substitui no banco
+ * e retorna classificação + jogos da rodada atual — dados 100% frescos.
+ * Rate limit: 1 req/2min por IP (proteger quota API-Football)
+ */
+const _refreshTimestamps = new Map(); // IP → timestamp do último refresh
+const REFRESH_COOLDOWN_MS = 2 * 60 * 1000; // 2 minutos
+
+router.post('/refresh/:temporada', async (req, res) => {
+    try {
+        const temporada = parseInt(req.params.temporada, 10);
+
+        if (isNaN(temporada) || temporada < 2020 || temporada > 2030) {
+            return res.status(400).json({
+                success: false,
+                erro: 'Temporada inválida',
+            });
+        }
+
+        // Rate limit por IP
+        const ip = req.ip || req.connection?.remoteAddress || 'unknown';
+        const ultimoRefresh = _refreshTimestamps.get(ip) || 0;
+        const agora = Date.now();
+
+        if (agora - ultimoRefresh < REFRESH_COOLDOWN_MS) {
+            const restante = Math.ceil((REFRESH_COOLDOWN_MS - (agora - ultimoRefresh)) / 1000);
+            return res.status(429).json({
+                success: false,
+                erro: `Aguarde ${restante}s para atualizar novamente`,
+            });
+        }
+
+        _refreshTimestamps.set(ip, agora);
+
+        // Force sync: rebusca das fontes externas com replaceMode
+        const syncResult = await brasileiraoService.sincronizarTabela(temporada, true);
+
+        if (!syncResult.success) {
+            return res.status(503).json(syncResult);
+        }
+
+        // Retornar dados frescos: classificação + jogos da rodada atual
+        const [classificacao, resumo] = await Promise.all([
+            brasileiraoService.obterClassificacao(temporada),
+            brasileiraoService.obterResumoParaExibicao(temporada),
+        ]);
+
+        res.json({
+            success: true,
+            fonte: syncResult.fonte,
+            jogosImportados: syncResult.jogosImportados,
+            classificacao: classificacao.classificacao || [],
+            rodada_atual: resumo.rodada_atual,
+            jogos_rodada_atual: resumo.jogos_rodada_atual || [],
+            ultima_atualizacao: new Date(),
+        });
+
+    } catch (error) {
+        console.error('[BRASILEIRAO-ROUTES] Erro refresh:', error);
+        res.status(500).json({
+            success: false,
+            erro: 'Erro ao atualizar dados do Brasileirão',
+        });
+    }
+});
+
 // =====================================================================
 // ENDPOINTS ADMIN (Requer autenticação)
 // =====================================================================

--- a/scripts/fix-brasileirao-full-resync.js
+++ b/scripts/fix-brasileirao-full-resync.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// =====================================================================
+// FIX BRASILEIRÃO FULL RESYNC
+// Limpa partidas corrompidas (lixo de seed aleatório) e reseta timestamps
+// para forçar re-sync completo das fontes externas (API-Football → ESPN).
+//
+// PROBLEMA: seed-brasileirao-2026-real.js gera confrontos ALEATÓRIOS para
+// R6-R38 via Math.random(). importarPartidas() nunca remove entradas stale.
+// Resultado: DB com mix de dados reais + lixo, classificação errada.
+//
+// Uso:
+//   node scripts/fix-brasileirao-full-resync.js           (dry-run)
+//   node scripts/fix-brasileirao-full-resync.js --force   (aplica)
+// =====================================================================
+
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const DRY_RUN = !process.argv.includes('--force');
+const TEMPORADA = 2026;
+
+if (DRY_RUN) {
+    console.log('⚠️  DRY-RUN — nenhuma alteração será feita. Use --force para aplicar.\n');
+} else {
+    console.log('🚀 MODO FORCE — partidas serão limpas para forçar re-sync.\n');
+}
+
+const MONGO_URI = process.env.MONGO_URI;
+if (!MONGO_URI) { console.error('❌ MONGO_URI não configurada'); process.exit(1); }
+
+try {
+    await mongoose.connect(MONGO_URI);
+    console.log('✅ Conectado ao MongoDB\n');
+
+    const db = mongoose.connection.db;
+    const col = db.collection('calendariobrasileiraos');
+
+    const doc = await col.findOne({ temporada: TEMPORADA });
+    if (!doc) {
+        console.error(`❌ Documento temporada ${TEMPORADA} não encontrado`);
+        process.exit(1);
+    }
+
+    const totalPartidas = doc.partidas?.length || 0;
+    const encerrados = (doc.partidas || []).filter(p => p.status === 'encerrado').length;
+    const agendados = (doc.partidas || []).filter(p => p.status === 'agendado').length;
+    const adiados = (doc.partidas || []).filter(p => p.status === 'adiado').length;
+
+    console.log(`📊 Estado atual da temporada ${TEMPORADA}:`);
+    console.log(`   Total partidas: ${totalPartidas}`);
+    console.log(`   Encerrados:     ${encerrados}`);
+    console.log(`   Agendados:      ${agendados}`);
+    console.log(`   Adiados:        ${adiados}`);
+    console.log(`   Fonte:          ${doc.fonte}`);
+    console.log(`   Última att:     ${doc.ultima_atualizacao}`);
+    console.log(`   Remarcações:    ${doc.remarcacoes?.length || 0}`);
+
+    // Diagnóstico: rodadas com jogos
+    const jogosParaRodada = {};
+    for (const p of (doc.partidas || [])) {
+        jogosParaRodada[p.rodada] = (jogosParaRodada[p.rodada] || 0) + 1;
+    }
+    console.log('\n📋 Jogos por rodada:');
+    for (let r = 1; r <= 15; r++) {
+        const count = jogosParaRodada[r] || 0;
+        const flag = count !== 10 ? ' ⚠️' : '';
+        console.log(`   R${String(r).padStart(2, '0')}: ${count} jogos${flag}`);
+    }
+    const totalRodadas = Object.keys(jogosParaRodada).length;
+    if (totalRodadas > 15) {
+        console.log(`   ... (${totalRodadas} rodadas no total)`);
+    }
+
+    if (DRY_RUN) {
+        console.log('\n⚠️  DRY-RUN concluído. Execute com --force para limpar partidas e forçar re-sync.');
+        process.exit(0);
+    }
+
+    // Limpar partidas e resetar timestamps
+    const seteAtras = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    await col.updateOne(
+        { temporada: TEMPORADA },
+        {
+            $set: {
+                partidas: [],
+                stats: {
+                    total_jogos: 0,
+                    jogos_realizados: 0,
+                    jogos_restantes: 0,
+                    rodada_atual: 1,
+                    ultima_rodada_completa: 0,
+                },
+                ultima_atualizacao: seteAtras,
+            }
+        }
+    );
+
+    console.log(`\n✅ Partidas limpas (${totalPartidas} → 0)`);
+    console.log(`✅ ultima_atualizacao resetada para ${seteAtras.toISOString()}`);
+    console.log('\n📌 Próximo passo: POST /api/brasileirao/sync/2026 (admin) ou clicar Atualizar na LP');
+    console.log('   O sistema vai rebuscar tudo das fontes externas (API-Football → ESPN).');
+
+} finally {
+    await mongoose.disconnect();
+    console.log('\n🔌 Desconectado do MongoDB');
+}

--- a/services/brasileirao-tabela-service.js
+++ b/services/brasileirao-tabela-service.js
@@ -261,7 +261,10 @@ async function buscarViaEspn(temporada) {
 
     // ESPN scoreboard não suporta ranges longos confiávelmente.
     // Brasileirão vai de março a dezembro — buscar mês a mês e mesclar.
-    const MESES_TEMPORADA = ['03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
+    // Meses dinâmicos baseados em BRASILEIRAO_INICIO (2026 começa em janeiro por causa da Copa do Mundo)
+    const mesInicio = parseInt((BRASILEIRAO_INICIO[temporada] || '').substring(5, 7) || '04', 10);
+    const MESES_TEMPORADA = [];
+    for (let m = mesInicio; m <= 12; m++) MESES_TEMPORADA.push(String(m).padStart(2, '0'));
 
     /**
      * Busca jogos de um mês específico via ESPN scoreboard.
@@ -700,13 +703,17 @@ async function sincronizarTabela(temporada, forcar = false) {
 
     // Se conseguiu dados, salvar
     if (partidas && partidas.length > 0) {
-        const calendario = await CalendarioBrasileirao.importarPartidas(temporada, partidas, fonte);
+        // Full sync: replaceMode elimina lixo de seeds/syncs antigos
+        const calendario = await CalendarioBrasileirao.importarPartidas(temporada, partidas, fonte, { replaceMode: true });
 
         state.ultimoSync = new Date();
         state.fonteAtual = fonte;
         state.erro = null;
         state.stats.syncCount++;
         state.stats.lastSuccess = { fonte, jogos: partidas.length, data: new Date() };
+
+        // Invalidar cache de classificação — dados mudaram
+        _classificacaoCache.ts = 0;
 
         console.log(`[BRASILEIRAO-SERVICE] ✅ Sync completo: ${partidas.length} jogos via ${fonte}`);
 


### PR DESCRIPTION
Causa raiz: seed gerava confrontos aleatórios para R6-38, importarPartidas
fazia merge mas nunca removia entradas stale, ESPN não buscava meses Jan-Fev.

- Adiciona replaceMode ao importarPartidas (substitui todas partidas em vez
  de merge, eliminando lixo de seeds/syncs antigos)
- Usa replaceMode: true em todo sync completo (sincronizarTabela)
- Corrige MESES_TEMPORADA dinâmico baseado em BRASILEIRAO_INICIO (2026=Jan)
- Novo endpoint POST /refresh/:temporada (público, rate limit 2min/IP)
  que rebusca das fontes externas e retorna dados frescos
- Botão Atualizar da LP agora chama /refresh (organismo vivo)
- Invalida cache de classificação após cada sync completo
- Script fix-brasileirao-full-resync.js para limpeza one-time do banco

https://claude.ai/code/session_01RNKZqXxRfUSEmeRtAryMCL