### PR TITLE
feat(ia): Big Cartola IA — Fases 2, 3 e 4 (11 tools + chips UI)

### DIFF
--- a/public/participante/js/modules/participante-chatbot.js
+++ b/public/participante/js/modules/participante-chatbot.js
@@ -31,6 +31,7 @@ const SUGESTOES_POR_MODULO = {
     ],
     extrato: [
         { rotulo: 'Meu saldo', pergunta: 'Qual meu saldo financeiro na liga?' },
+        { rotulo: 'Meu extrato', pergunta: 'Me mostre meu extrato detalhado da liga.' },
     ],
     turnoReturno: [
         { rotulo: 'Meu turno', pergunta: 'Como estou no turno?' },
@@ -38,12 +39,37 @@ const SUGESTOES_POR_MODULO = {
     restaUm: [
         { rotulo: 'Resta Um', pergunta: 'Estou vivo no Resta Um?' },
     ],
+    melhorMes: [
+        { rotulo: 'Melhor do Mes', pergunta: 'Quem ganhou o Melhor do Mes?' },
+        { rotulo: 'Meu Melhor do Mes', pergunta: 'Como estou no Melhor do Mes?' },
+    ],
+    mataMata: [
+        { rotulo: 'Minha chave', pergunta: 'Qual minha chave no Mata-Mata?' },
+        { rotulo: 'Passei de fase?', pergunta: 'Passei de fase no Mata-Mata?' },
+    ],
+    top10: [
+        { rotulo: 'Mitos e Micos', pergunta: 'Quem sao os mitos e micos da ultima rodada?' },
+    ],
+    tiroCerto: [
+        { rotulo: 'Tiro Certo', pergunta: 'Ainda estou vivo no Tiro Certo?' },
+    ],
+    luvaOuro: [
+        { rotulo: 'Luva de Ouro', pergunta: 'Quem esta liderando a Luva de Ouro?' },
+    ],
+    artilheiro: [
+        { rotulo: 'Artilheiro', pergunta: 'Quem e o artilheiro da liga?' },
+    ],
+    capitaoLuxo: [
+        { rotulo: 'Capitao de Luxo', pergunta: 'Quem e o melhor capitao da liga?' },
+    ],
 };
 
 // Sugestoes sempre presentes.
 const SUGESTOES_UNIVERSAIS = [
     { rotulo: 'Rodada atual', pergunta: 'Em qual rodada estamos e o mercado esta aberto?' },
-    { rotulo: 'Modulos ativos', pergunta: 'Quais modulos estao ativos na minha liga?' },
+    { rotulo: 'Minha rodada', pergunta: 'Quantos pontos fiz na ultima rodada?' },
+    { rotulo: 'Ranking da rodada', pergunta: 'Quem foi o cartoleiro da ultima rodada?' },
+    { rotulo: 'Jogos hoje', pergunta: 'Tem jogo do Cartola hoje?' },
 ];
 
 let conversas = [];
@@ -398,6 +424,14 @@ async function popularSugestoesDinamicas() {
                     extrato: 'extrato',
                     turno_returno: 'turnoReturno',
                     resta_um: 'restaUm',
+                    melhor_mes: 'melhorMes',
+                    mata_mata: 'mataMata',
+                    top10: 'top10',
+                    top_10: 'top10',
+                    tiro_certo: 'tiroCerto',
+                    luva_ouro: 'luvaOuro',
+                    artilheiro: 'artilheiro',
+                    capitao_luxo: 'capitaoLuxo',
                 };
 
                 for (const m of listaMod) {

--- a/services/ia/chatbotService.js
+++ b/services/ia/chatbotService.js
@@ -46,6 +46,11 @@ GUIA DE DESAMBIGUACAO (qual tool chamar):
 - "mitos e micos", "top 10", "quem sao os mitos", "quem sao os micos": chame 'top_dez_mitos_micos'. Se mencionar rodada especifica, passe rodada=X.
 - "tiro certo", "ainda estou vivo", "quantas rodadas sobrevivi", "minha escolha no tiro certo": chame 'tiro_certo_status'.
 - "goleiro da rodada X", "quem ganhou o goleiro na rodada", "ranking defensivo rodada": chame 'goleiros_top' com rodada=X. Para ranking acumulado da temporada, prefira 'luva_de_ouro'.
+- "meu extrato detalhado", "meus lancamentos", "quanto ganhei/perdi", "por que meu saldo e X": chame 'meu_extrato_detalhado'. Se nao quiser todos, passe ultimas_rodadas=N.
+- "minha inscricao", "status da inscricao", "estou em dia", "sou devedor", "paguei a inscricao": chame 'minhas_inscricoes'.
+- "como e configurado o X nesta liga", "quantas edicoes tem o melhor do mes", "formato do mata-mata aqui": chame 'config_liga_detalhada'.
+- "qual a taxa da liga", "posso parcelar", "prazo de renovacao", "regras gerais da liga": chame 'regras_liga_gerais'.
+- "tem jogo hoje", "jogos do cartola hoje", "quem joga hoje", "jogos ao vivo", "resultado de hoje": chame 'jogos_do_dia'.
 - Perguntas genericas "como esta X" onde X e um modulo, chame a tool especifica do modulo, nao 'top_n_liga_generico'.
 - Se nao tiver certeza de qual tool e a certa, primeiro chame 'modulos_ativos_liga' para listar os modulos ativos, depois escolha.
 

--- a/services/ia/chatbotService.js
+++ b/services/ia/chatbotService.js
@@ -37,9 +37,15 @@ GUIA DE DESAMBIGUACAO (qual tool chamar):
 - "melhor do mes", "premiacao mensal", "campeao do mes": chame 'melhor_do_mes'. Se o usuario disser "edicao 2", "edicao 3" etc, passe edicao_id numerico. Sem numero, deixe edicao_id vazio para obter resumo de TODAS as edicoes.
 - "como estou no melhor do mes", "ja ganhei alguma edicao": chame 'meu_desempenho_melhor_mes'.
 - "artilheiro", "gols pro", "gols contra", "saldo de gols": chame 'artilheiro_campeao'.
-- "luva de ouro", "ranking de goleiros", "melhor goleiro": chame 'luva_de_ouro'.
+- "luva de ouro", "ranking de goleiros acumulado", "melhor goleiro da temporada": chame 'luva_de_ouro'.
 - "capitao", "melhor capitao", "capitao de luxo": chame 'capitao_de_luxo'.
 - "pontos corridos", "tabela", "minha posicao", "meu confronto": prefira 'minha_classificacao_pontos_corridos' ou 'meu_proximo_confronto_pc'.
+- "quantos pontos fiz na rodada X", "minha escalacao na rodada X", "como fui na rodada": chame 'pontuacao_rodada' com rodada=X. Sem numero de rodada, omite o argumento (retorna a mais recente).
+- "quem foi o cartoleiro da rodada X", "ranking da rodada X", "quem pontuou mais na rodada", "mico da rodada": chame 'ranking_rodada' com rodada=X.
+- "mata-mata", "minha chave", "contra quem jogo", "passei de fase", "fui eliminado": chame 'mata_mata_situacao'.
+- "mitos e micos", "top 10", "quem sao os mitos", "quem sao os micos": chame 'top_dez_mitos_micos'. Se mencionar rodada especifica, passe rodada=X.
+- "tiro certo", "ainda estou vivo", "quantas rodadas sobrevivi", "minha escolha no tiro certo": chame 'tiro_certo_status'.
+- "goleiro da rodada X", "quem ganhou o goleiro na rodada", "ranking defensivo rodada": chame 'goleiros_top' com rodada=X. Para ranking acumulado da temporada, prefira 'luva_de_ouro'.
 - Perguntas genericas "como esta X" onde X e um modulo, chame a tool especifica do modulo, nao 'top_n_liga_generico'.
 - Se nao tiver certeza de qual tool e a certa, primeiro chame 'modulos_ativos_liga' para listar os modulos ativos, depois escolha.
 

--- a/services/ia/mongoHelpers.js
+++ b/services/ia/mongoHelpers.js
@@ -6,7 +6,8 @@
  *   - ObjectId: ligas._id, rodadas.ligaId, pontoscorridoscaches.liga_id, capitaocaches.ligaId
  *   - String:   moduleconfigs.liga_id, rankinggeralcaches.ligaId, melhor_mes_cache.ligaId,
  *               rankingturnos.ligaId, top10caches.liga_id, artilheirocampeaos.ligaId,
- *               tirocertocaches.liga_id, goleiros.ligaId, restaumcaches.liga_id
+ *               tirocertocaches.liga_id, goleiros.ligaId, restaumcaches.liga_id,
+ *               matamatacaches.liga_id
  *
  * Este modulo exporta helpers para obter o filtro correto por collection.
  */
@@ -47,6 +48,7 @@ const LIGA_ID_FORMAT = {
     restaumcaches: { field: 'liga_id', format: 'string' },
     fluxofinanceirocampos: { field: 'liga_id', format: 'string' },
     extratofinanceirocaches: { field: 'liga_id', format: 'string' },
+    matamatacaches: { field: 'liga_id', format: 'string' },
 };
 
 /**

--- a/services/ia/mongoHelpers.js
+++ b/services/ia/mongoHelpers.js
@@ -4,10 +4,12 @@
  * Centraliza normalizacao de `liga_id`/`ligaId` entre collections.
  * No projeto, diferentes collections armazenam o ID da liga em formatos diferentes:
  *   - ObjectId: ligas._id, rodadas.ligaId, pontoscorridoscaches.liga_id, capitaocaches.ligaId
+ *   - ObjectId: ligas._id, rodadas.ligaId, pontoscorridoscaches.liga_id, capitaocaches.ligaId,
+ *               inscricoestemporada.liga_id, ligarules.liga_id
  *   - String:   moduleconfigs.liga_id, rankinggeralcaches.ligaId, melhor_mes_cache.ligaId,
  *               rankingturnos.ligaId, top10caches.liga_id, artilheirocampeaos.ligaId,
  *               tirocertocaches.liga_id, goleiros.ligaId, restaumcaches.liga_id,
- *               matamatacaches.liga_id
+ *               matamatacaches.liga_id, extratofinanceirocaches.liga_id
  *
  * Este modulo exporta helpers para obter o filtro correto por collection.
  */
@@ -49,6 +51,9 @@ const LIGA_ID_FORMAT = {
     fluxofinanceirocampos: { field: 'liga_id', format: 'string' },
     extratofinanceirocaches: { field: 'liga_id', format: 'string' },
     matamatacaches: { field: 'liga_id', format: 'string' },
+    inscricoestemporada: { field: 'liga_id', format: 'objectId' },
+    ligarules: { field: 'liga_id', format: 'objectId' },
+    ajustesfinanceiros: { field: 'liga_id', format: 'string' },
 };
 
 /**

--- a/services/ia/toolRegistry.js
+++ b/services/ia/toolRegistry.js
@@ -36,6 +36,12 @@ import mataMataSituacao from './tools/mataMataSituacao.js';
 import topDezMitosMicos from './tools/topDezMitosMicos.js';
 import tiroCertoStatus from './tools/tiroCertoStatus.js';
 import goleirosTop from './tools/goleirosTop.js';
+// Fase 3 — Financeiro detalhado + config + jogos
+import meuExtratoDetalhado from './tools/meuExtratoDetalhado.js';
+import minhasInscricoes from './tools/minhasInscricoes.js';
+import configLigaDetalhada from './tools/configLigaDetalhada.js';
+import regrasLigaGerais from './tools/regrasLigaGerais.js';
+import jogosDoDia from './tools/jogosDoDia.js';
 
 /**
  * Lista ordenada de tools disponiveis para o LLM.
@@ -65,6 +71,12 @@ export const TOOLS = [
     topDezMitosMicos,
     tiroCertoStatus,
     goleirosTop,
+    // Fase 3
+    meuExtratoDetalhado,
+    minhasInscricoes,
+    configLigaDetalhada,
+    regrasLigaGerais,
+    jogosDoDia,
 ];
 
 /**

--- a/services/ia/toolRegistry.js
+++ b/services/ia/toolRegistry.js
@@ -29,6 +29,13 @@ import meuDesempenhoMelhorMes from './tools/meuDesempenhoMelhorMes.js';
 import artilheiroCampeao from './tools/artilheiroCampeao.js';
 import luvaDeOuro from './tools/luvaDeOuro.js';
 import capitaoDoMes from './tools/capitaoDoMes.js';
+// Fase 2 — Desempenho por rodada + mata-mata + top 10
+import pontuacaoRodada from './tools/pontuacaoRodada.js';
+import rankingRodada from './tools/rankingRodada.js';
+import mataMataSituacao from './tools/mataMataSituacao.js';
+import topDezMitosMicos from './tools/topDezMitosMicos.js';
+import tiroCertoStatus from './tools/tiroCertoStatus.js';
+import goleirosTop from './tools/goleirosTop.js';
 
 /**
  * Lista ordenada de tools disponiveis para o LLM.
@@ -51,6 +58,13 @@ export const TOOLS = [
     artilheiroCampeao,
     luvaDeOuro,
     capitaoDoMes,
+    // Fase 2
+    pontuacaoRodada,
+    rankingRodada,
+    mataMataSituacao,
+    topDezMitosMicos,
+    tiroCertoStatus,
+    goleirosTop,
 ];
 
 /**

--- a/services/ia/tools/configLigaDetalhada.js
+++ b/services/ia/tools/configLigaDetalhada.js
@@ -1,0 +1,82 @@
+/**
+ * TOOL: config_liga_detalhada
+ *
+ * Retorna as configuracoes customizadas da liga:
+ *   - Liga.configuracoes (por modulo: pontos_corridos, mata_mata, etc.)
+ *   - ModuleConfig.wizard_respostas de cada modulo ativo (customizacoes do wizard)
+ *
+ * Util para responder perguntas como "qual e o formato do mata-mata da minha liga",
+ * "quantas edicoes tem o melhor do mes aqui", "qual a premiacao do pontos corridos".
+ * Multi-tenant: ligaId vem do ctx.
+ */
+
+import { filtroLiga } from '../mongoHelpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+export default {
+    name: 'config_liga_detalhada',
+    description:
+        'Retorna as configuracoes customizadas desta liga: formato do mata-mata, numero de edicoes do melhor do mes, premiacao dos modulos, etc. Use quando perguntarem "como e o mata-mata aqui", "quantas edicoes tem o melhor do mes", "qual o formato da liga", "qual a premiacao do X", "como esta configurado o Y nesta liga".',
+    parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+    },
+
+    async handler({ ctx, db }) {
+        const filtroLigas = filtroLiga('ligas', ctx.ligaId);
+        if (!filtroLigas) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+
+        // Buscar configuracoes da liga
+        const liga = await db
+            .collection('ligas')
+            .findOne(filtroLigas, {
+                projection: {
+                    nome: 1,
+                    configuracoes: 1,
+                    modulos_ativos: 1,
+                    status: 1,
+                    temporada: 1,
+                },
+            });
+
+        if (!liga) return { erro: 'liga_nao_encontrada' };
+
+        // Buscar wizard_respostas de todos os modulos configurados
+        const filtroMod = filtroLiga('moduleconfigs', ctx.ligaId);
+        let modulosConfig = [];
+        if (filtroMod) {
+            const docs = await db
+                .collection('moduleconfigs')
+                .find({ ...filtroMod, temporada })
+                .project({ modulo: 1, ativo: 1, wizard_respostas: 1 })
+                .toArray();
+
+            modulosConfig = docs
+                .filter(d => d.wizard_respostas && Object.keys(d.wizard_respostas).length > 0)
+                .map(d => ({
+                    modulo: d.modulo,
+                    ativo: !!d.ativo,
+                    configuracoes_wizard: d.wizard_respostas,
+                }));
+        }
+
+        // Modulos ativos (chaves true)
+        const modulosAtivos = liga.modulos_ativos
+            ? Object.entries(liga.modulos_ativos)
+                  .filter(([, v]) => v === true)
+                  .map(([k]) => k)
+            : [];
+
+        return {
+            liga: liga.nome || null,
+            temporada: liga.temporada ?? temporada,
+            status: liga.status ?? null,
+            modulos_ativos: modulosAtivos,
+            configuracoes_por_modulo: liga.configuracoes ?? {},
+            wizard_respostas_por_modulo: modulosConfig,
+        };
+    },
+};

--- a/services/ia/tools/goleirosTop.js
+++ b/services/ia/tools/goleirosTop.js
@@ -1,0 +1,135 @@
+/**
+ * TOOL: goleiros_top
+ *
+ * Retorna o ranking de goleiros (Luva de Ouro) de uma rodada especifica.
+ * Complementa `luva_de_ouro` (acumulado da temporada) com o ranking por rodada.
+ *
+ * Usa aggregation na collection `goleiros` (ligaId String).
+ * Verifica Liga.modulos_ativos.luvaOuro. Multi-tenant: ligaId vem do ctx.
+ */
+
+import { filtroLiga } from '../mongoHelpers.js';
+import { truncarPontosNum } from '../../../utils/type-helpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+async function moduloAtivo(db, ligaId) {
+    const filtro = filtroLiga('ligas', ligaId);
+    if (!filtro) return false;
+    const liga = await db
+        .collection('ligas')
+        .findOne(filtro, { projection: { modulos_ativos: 1, configuracoes: 1 } });
+    return (
+        liga?.modulos_ativos?.luvaOuro === true ||
+        liga?.configuracoes?.luva_ouro?.habilitado === true
+    );
+}
+
+export default {
+    name: 'goleiros_top',
+    description:
+        'Retorna o ranking defensivo (Luva de Ouro) de uma rodada especifica: quem escolheu o melhor goleiro naquela rodada. Sem rodada, usa a rodada concluida mais recente. Diferente de luva_de_ouro (que e o acumulado da temporada). Use quando perguntarem "quem ganhou o goleiro na rodada X", "melhor goleiro da rodada X", "ranking de goleiros da rodada".',
+    parameters: {
+        type: 'object',
+        properties: {
+            rodada: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 38,
+                description:
+                    'Numero da rodada. Omitir para usar a rodada concluida mais recente.',
+            },
+            top_n: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 20,
+                description: 'Quantos participantes retornar (padrao 5, max 20).',
+            },
+        },
+        additionalProperties: false,
+    },
+
+    async handler({ args, ctx, db }) {
+        const ativo = await moduloAtivo(db, ctx.ligaId);
+        if (!ativo) {
+            return {
+                modulo_ativo: false,
+                mensagem: 'O modulo Luva de Ouro nao esta ativo nesta liga.',
+            };
+        }
+
+        const filtroBase = filtroLiga('goleiros', ctx.ligaId);
+        if (!filtroBase) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+        const topN = Math.min(Number(args?.top_n) || 5, 20);
+
+        // Determinar rodada
+        let rodadaNum = args?.rodada ? Number(args.rodada) : null;
+
+        if (!rodadaNum) {
+            const ultima = await db
+                .collection('goleiros')
+                .findOne(
+                    { ...filtroBase, temporada, rodadaConcluida: true },
+                    { sort: { rodada: -1 }, projection: { rodada: 1 } }
+                );
+            if (!ultima) {
+                return {
+                    modulo_ativo: true,
+                    mensagem: 'Ainda nao ha rodadas concluidas de goleiros nesta liga.',
+                };
+            }
+            rodadaNum = ultima.rodada;
+        }
+
+        // Aggregation: agrupar por participanteId para a rodada especifica
+        const pipeline = [
+            {
+                $match: {
+                    ...filtroBase,
+                    temporada,
+                    rodada: rodadaNum,
+                    rodadaConcluida: true,
+                },
+            },
+            {
+                $group: {
+                    _id: '$participanteId',
+                    nome_cartola: { $first: '$nomeCartoleiro' },
+                    nome_time: { $first: '$nomeTime' },
+                    timeId: { $first: '$timeId' },
+                    pontos_rodada: { $sum: '$pontos' },
+                },
+            },
+            { $sort: { pontos_rodada: -1 } },
+            { $limit: topN + 1 }, // +1 para capturar posicao do usuario se necessario
+        ];
+
+        const resultados = await db
+            .collection('goleiros')
+            .aggregate(pipeline)
+            .toArray();
+
+        if (!resultados.length) {
+            return {
+                modulo_ativo: true,
+                rodada: rodadaNum,
+                mensagem: `Nao ha dados de goleiros consolidados para a rodada ${rodadaNum}.`,
+            };
+        }
+
+        const top = resultados.slice(0, topN).map((r, i) => ({
+            posicao: i + 1,
+            nome_cartola: r.nome_cartola || null,
+            nome_time: r.nome_time || null,
+            pontos: truncarPontosNum(r.pontos_rodada ?? 0),
+            meu_time: Number(r.timeId) === Number(ctx.timeId),
+        }));
+
+        return {
+            modulo_ativo: true,
+            rodada: rodadaNum,
+            top,
+        };
+    },
+};

--- a/services/ia/tools/jogosDoDia.js
+++ b/services/ia/tools/jogosDoDia.js
@@ -1,0 +1,94 @@
+/**
+ * TOOL: jogos_do_dia
+ *
+ * Retorna os jogos do Brasileirao agendados/ao vivo/encerrados do dia atual.
+ * Consome o cache de processo do api-orchestrator (API-Football / SoccerDataAPI).
+ *
+ * Nao requer ligaId/timeId — e informacao global, nao por-liga.
+ * Multi-tenant: sem filtro de liga (dado publico do Cartola FC).
+ */
+
+import apiOrchestrator from '../../../services/api-orchestrator.js';
+
+/**
+ * Mapa de status raw -> descricao amigavel em PT-BR.
+ */
+const STATUS_PT = {
+    '1H': 'Primeiro tempo',
+    '2H': 'Segundo tempo',
+    'HT': 'Intervalo',
+    'ET': 'Prorrogacao',
+    'BT': 'Intervalo prorrogacao',
+    'P': 'Penaltis',
+    'FT': 'Encerrado',
+    'AET': 'Encerrado (prorrogacao)',
+    'PEN': 'Encerrado (penaltis)',
+    'NS': 'Nao iniciado',
+    'PST': 'Adiado',
+    'CANC': 'Cancelado',
+    'SUSP': 'Suspenso',
+    'LIVE': 'Ao vivo',
+};
+
+function traduzirStatus(raw) {
+    return STATUS_PT[raw] || raw || 'Desconhecido';
+}
+
+export default {
+    name: 'jogos_do_dia',
+    description:
+        'Retorna os jogos do Brasileirao (e outras competicoes brasileiras) agendados para hoje, incluindo ao vivo e encerrados. Use quando perguntarem "tem jogo hoje", "quais jogos tem hoje", "quem joga hoje no Cartola", "jogos ao vivo", "resultado do jogo de hoje".',
+    parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+    },
+
+    async handler() {
+        try {
+            const resultado = await apiOrchestrator.buscarFixturesDoDia();
+            const jogos = Array.isArray(resultado?.jogos) ? resultado.jogos : [];
+
+            if (!jogos.length) {
+                return {
+                    fonte: resultado?.fonte ?? 'sem-dados',
+                    mensagem: 'Nao ha jogos brasileiros registrados para hoje.',
+                    jogos: [],
+                };
+            }
+
+            const formatados = jogos.map(j => ({
+                mandante: j.mandante || j.homeTeam || null,
+                visitante: j.visitante || j.awayTeam || null,
+                placar_mandante: j.placar_mandante ?? j.homeScore ?? null,
+                placar_visitante: j.placar_visitante ?? j.awayScore ?? null,
+                status: traduzirStatus(j.statusRaw || j.status),
+                ao_vivo: !!j.aoVivo,
+                horario: j.horario || j.hora || null,
+                competicao: j.competicao || j.league || null,
+            }));
+
+            const aoVivo = formatados.filter(j => j.ao_vivo);
+            const encerrados = formatados.filter(j =>
+                ['Encerrado', 'Encerrado (prorrogacao)', 'Encerrado (penaltis)'].includes(j.status)
+            );
+            const agendados = formatados.filter(
+                j => !j.ao_vivo && !encerrados.includes(j)
+            );
+
+            return {
+                fonte: resultado?.fonte ?? 'api',
+                total_jogos: formatados.length,
+                ao_vivo: aoVivo,
+                agendados,
+                encerrados,
+            };
+        } catch (err) {
+            return {
+                erro: 'falha_ao_buscar_jogos',
+                detalhe: err.message,
+                mensagem: 'Nao foi possivel buscar os jogos do dia no momento.',
+            };
+        }
+    },
+};

--- a/services/ia/tools/mataMataSituacao.js
+++ b/services/ia/tools/mataMataSituacao.js
@@ -1,0 +1,192 @@
+/**
+ * TOOL: mata_mata_situacao
+ *
+ * Lista todas as edicoes do Mata-Mata da liga, indicando em qual o
+ * participante logado tem confronto ativo/pendente (fase atual) e
+ * qual a situacao de cada confronto encontrado.
+ *
+ * Multi-tenant: ligaId vem do ctx.
+ */
+
+import { filtroLiga } from '../mongoHelpers.js';
+import { truncarPontosNum } from '../../../utils/type-helpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+const FASES_ORDEM = ['primeira', 'oitavas', 'quartas', 'semis', 'final'];
+
+/**
+ * Verifica se o modulo mata-mata esta ativo na liga.
+ */
+async function moduloAtivo(db, ligaId) {
+    const filtro = filtroLiga('ligas', ligaId);
+    if (!filtro) return false;
+    const liga = await db
+        .collection('ligas')
+        .findOne(filtro, { projection: { modulos_ativos: 1 } });
+    return liga?.modulos_ativos?.mataMata === true;
+}
+
+/**
+ * Procura o confronto do timeId em todas as fases do dados_torneio.
+ * Retorna { fase, confronto } ou null.
+ */
+function encontrarMeuConfronto(dadosTorneio, timeId) {
+    if (!dadosTorneio) return null;
+    const tid = Number(timeId);
+
+    for (const fase of FASES_ORDEM) {
+        const confrontos = dadosTorneio[fase];
+        if (!Array.isArray(confrontos)) continue;
+
+        for (const c of confrontos) {
+            const idA = Number(c?.timeA?.timeId ?? c?.timeA?.id ?? -1);
+            const idB = Number(c?.timeB?.timeId ?? c?.timeB?.id ?? -1);
+
+            if (idA === tid || idB === tid) {
+                return { fase, confronto: c };
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Determina a fase atual com base em dados_torneio.fases e rodada_atual.
+ */
+function faseDaRodada(dadosTorneio, rodadaAtual) {
+    const fases = dadosTorneio?.fases;
+    if (!fases || !rodadaAtual) return null;
+
+    for (const nome of FASES_ORDEM) {
+        if (Number(fases[nome]) === Number(rodadaAtual)) return nome;
+    }
+    return null;
+}
+
+/**
+ * Determina status do confronto: 'aguardando', 'em_andamento', 'concluido'.
+ */
+function statusConfronto(c) {
+    const pA = c?.timeA?.pontos;
+    const pB = c?.timeB?.pontos;
+    if (typeof pA !== 'number' && typeof pB !== 'number') return 'aguardando';
+    if (typeof pA !== 'number' || typeof pB !== 'number') return 'em_andamento';
+    return 'concluido';
+}
+
+/**
+ * Determina o vencedor do confronto (timeId), ou null se inconclusivo.
+ */
+function vencedorConfronto(c) {
+    const pA = c?.timeA?.pontos;
+    const pB = c?.timeB?.pontos;
+    if (typeof pA !== 'number' || typeof pB !== 'number') return null;
+    if (pA > pB) return Number(c.timeA.timeId ?? c.timeA.id);
+    if (pB > pA) return Number(c.timeB.timeId ?? c.timeB.id);
+    // Empate: timeA vence por ser classificado melhor
+    return Number(c.timeA.timeId ?? c.timeA.id);
+}
+
+export default {
+    name: 'mata_mata_situacao',
+    description:
+        'Lista todas as edicoes do Mata-Mata desta liga com o confronto do participante logado em cada uma. Enfatiza qual edicao esta ativa/pendente de acao. Use quando perguntarem "minha chave no mata-mata", "contra quem jogo", "como estou no mata-mata", "passei de fase?", "fui eliminado?".',
+    parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+    },
+
+    async handler({ ctx, db }) {
+        const ativo = await moduloAtivo(db, ctx.ligaId);
+        if (!ativo) {
+            return {
+                modulo_ativo: false,
+                mensagem: 'O modulo Mata-Mata nao esta ativo nesta liga.',
+            };
+        }
+
+        const filtro = filtroLiga('matamatacaches', ctx.ligaId);
+        if (!filtro) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+        const timeId = Number(ctx.timeId);
+
+        const edicoes = await db
+            .collection('matamatacaches')
+            .find({ ...filtro, temporada })
+            .sort({ edicao: 1 })
+            .toArray();
+
+        if (!edicoes.length) {
+            return {
+                modulo_ativo: true,
+                mensagem: 'Ainda nao ha dados de Mata-Mata consolidados para esta liga.',
+                total_edicoes: 0,
+                edicoes: [],
+            };
+        }
+
+        const resultado = edicoes.map(ed => {
+            const dadosTorneio = ed.dados_torneio;
+            const faseAtual = faseDaRodada(dadosTorneio, ed.rodada_atual);
+            const encontrado = encontrarMeuConfronto(dadosTorneio, timeId);
+
+            let meuConfronto = null;
+            if (encontrado) {
+                const { fase, confronto: c } = encontrado;
+                const idA = Number(c?.timeA?.timeId ?? c?.timeA?.id);
+                const euSouA = idA === timeId;
+                const adversario = euSouA ? c.timeB : c.timeA;
+                const eu = euSouA ? c.timeA : c.timeB;
+                const venc = vencedorConfronto(c);
+                const status = statusConfronto(c);
+
+                meuConfronto = {
+                    fase,
+                    fase_atual: faseAtual,
+                    adversario: {
+                        nome_cartola: adversario.nome_cartola || adversario.nome || null,
+                        nome_time: adversario.nome_time || null,
+                        pontos: typeof adversario.pontos === 'number'
+                            ? truncarPontosNum(adversario.pontos)
+                            : null,
+                    },
+                    meus_pontos: typeof eu.pontos === 'number'
+                        ? truncarPontosNum(eu.pontos)
+                        : null,
+                    status,
+                    resultado: status === 'concluido'
+                        ? (venc === timeId ? 'classificado' : 'eliminado')
+                        : null,
+                };
+            }
+
+            // Determinar se esta edicao precisa de atencao
+            const precisaAtencao =
+                encontrado !== null &&
+                meuConfronto?.resultado !== 'eliminado' &&
+                (meuConfronto?.status === 'aguardando' ||
+                    meuConfronto?.status === 'em_andamento');
+
+            return {
+                edicao: ed.edicao,
+                rodada_atual: ed.rodada_atual ?? null,
+                fase_atual: faseAtual,
+                tamanho_torneio: ed.tamanhoTorneio ?? null,
+                meu_confronto: meuConfronto,
+                atencao_necessaria: precisaAtencao,
+            };
+        });
+
+        // Edicao que precisa de atencao (ativa para o usuario)
+        const edicaoAtiva = resultado.find(e => e.atencao_necessaria) ?? null;
+
+        return {
+            modulo_ativo: true,
+            total_edicoes: resultado.length,
+            edicao_com_atencao: edicaoAtiva ? edicaoAtiva.edicao : null,
+            edicoes: resultado,
+        };
+    },
+};

--- a/services/ia/tools/meuExtratoDetalhado.js
+++ b/services/ia/tools/meuExtratoDetalhado.js
@@ -1,0 +1,106 @@
+/**
+ * TOOL: meu_extrato_detalhado
+ *
+ * Retorna a lista itemizada de lancamentos financeiros do participante logado:
+ * historico de rodadas (bonus/onus, premios, top10, mata-mata) + ajustes
+ * manuais (admin). Ordena do mais recente para o mais antigo.
+ *
+ * Fontes:
+ *   - extratofinanceirocaches.historico_transacoes (liga_id String, time_id Number)
+ *   - ajustesfinanceiros (liga_id String, time_id Number)
+ *
+ * Multi-tenant: ligaId/timeId vem do ctx.
+ */
+
+import { filtroLiga, toObjectId } from '../mongoHelpers.js';
+import { truncarPontosNum } from '../../../utils/type-helpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+export default {
+    name: 'meu_extrato_detalhado',
+    description:
+        'Retorna a lista itemizada de lancamentos financeiros do participante: bonus/onus por rodada, premios, ajustes manuais, saldo acumulado. Use quando perguntarem "meu extrato detalhado", "quais foram meus ganhos/perdas", "quanto ganhei na rodada X", "meus lancamentos financeiros", "por que meu saldo e esse".',
+    parameters: {
+        type: 'object',
+        properties: {
+            ultimas_rodadas: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 38,
+                description:
+                    'Quantas rodadas retornar (padrao 10, max 38). Retorna as mais recentes primeiro.',
+            },
+        },
+        additionalProperties: false,
+    },
+
+    async handler({ args, ctx, db }) {
+        const filtroExtrato = filtroLiga('extratofinanceirocaches', ctx.ligaId);
+        if (!filtroExtrato) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+        const timeId = Number(ctx.timeId);
+        const limite = Math.min(Number(args?.ultimas_rodadas) || 10, 38);
+
+        // Buscar extrato do cache
+        const extrato = await db
+            .collection('extratofinanceirocaches')
+            .findOne({ ...filtroExtrato, time_id: timeId, temporada });
+
+        if (!extrato) {
+            return {
+                mensagem: 'Ainda nao ha extrato financeiro consolidado para voce nesta liga.',
+                saldo_consolidado: 0,
+                lancamentos: [],
+            };
+        }
+
+        // Historico de rodadas, do mais recente para o mais antigo
+        const historico = (extrato.historico_transacoes || [])
+            .slice()
+            .sort((a, b) => b.rodada - a.rodada)
+            .slice(0, limite)
+            .map(h => ({
+                rodada: h.rodada,
+                posicao: h.posicao ?? null,
+                bonus_onus: truncarPontosNum(h.bonusOnus ?? h.valor ?? 0),
+                pontos_corridos: truncarPontosNum(h.pontosCorridos ?? 0),
+                mata_mata: truncarPontosNum(h.mataMata ?? 0),
+                top10: truncarPontosNum(h.top10 ?? 0),
+                saldo_rodada: truncarPontosNum(h.saldo ?? 0),
+                saldo_acumulado: truncarPontosNum(h.saldoAcumulado ?? 0),
+                foi_mito: !!h.isMito,
+                foi_mico: !!h.isMico,
+                descricao: h.descricao ?? null,
+            }));
+
+        // Ajustes manuais (tipo AJUSTE, rodada: null)
+        const filtroAjuste = filtroLiga('ajustesfinanceiros', ctx.ligaId);
+        let ajustes = [];
+        if (filtroAjuste) {
+            const docs = await db
+                .collection('ajustesfinanceiros')
+                .find({ ...filtroAjuste, time_id: timeId, temporada, ativo: true })
+                .sort({ createdAt: -1 })
+                .limit(10)
+                .toArray();
+
+            ajustes = docs.map(a => ({
+                tipo: 'AJUSTE',
+                rodada: null,
+                descricao: a.descricao || 'Ajuste manual',
+                valor: truncarPontosNum(a.valor ?? 0),
+                data: a.createdAt ?? null,
+            }));
+        }
+
+        return {
+            saldo_consolidado: truncarPontosNum(extrato.saldo_consolidado ?? 0),
+            ganhos_consolidados: truncarPontosNum(extrato.ganhos_consolidados ?? 0),
+            perdas_consolidadas: truncarPontosNum(extrato.perdas_consolidadas ?? 0),
+            ultima_rodada_consolidada: extrato.ultima_rodada_consolidada ?? 0,
+            historico_rodadas: historico,
+            ajustes_manuais: ajustes,
+        };
+    },
+};

--- a/services/ia/tools/minhasInscricoes.js
+++ b/services/ia/tools/minhasInscricoes.js
@@ -1,0 +1,65 @@
+/**
+ * TOOL: minhas_inscricoes
+ *
+ * Retorna os dados de inscricao do participante logado na temporada atual:
+ * taxa, status (ativo/devedor/suspenso), se pagou, saldo inicial, parcelamento.
+ *
+ * Consome `inscricoestemporada` (liga_id ObjectId, time_id Number).
+ * Multi-tenant: ligaId/timeId vem do ctx.
+ */
+
+import { filtroLiga } from '../mongoHelpers.js';
+import { truncarPontosNum } from '../../../utils/type-helpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+export default {
+    name: 'minhas_inscricoes',
+    description:
+        'Retorna os dados de inscricao do participante na temporada: taxa de inscricao, status (ativo, devedor, suspenso), se pagou a inscricao, saldo inicial, parcelamento. Use quando perguntarem "minha inscricao", "status da minha inscricao", "quanto paguei para entrar", "estou em dia com a liga", "sou devedor?".',
+    parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+    },
+
+    async handler({ ctx, db }) {
+        const filtro = filtroLiga('inscricoestemporada', ctx.ligaId);
+        if (!filtro) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+        const timeId = Number(ctx.timeId);
+
+        const inscricao = await db
+            .collection('inscricoestemporada')
+            .findOne({ ...filtro, time_id: timeId, temporada });
+
+        if (!inscricao) {
+            return {
+                mensagem: 'Nao ha registro de inscricao para voce nesta liga nesta temporada.',
+                temporada,
+            };
+        }
+
+        // Parcelamento (se existir)
+        const parcelas = Array.isArray(inscricao.parcelamento?.parcelas)
+            ? inscricao.parcelamento.parcelas.map(p => ({
+                  numero: p.numero,
+                  valor: truncarPontosNum(p.valor ?? 0),
+                  status: p.status ?? null,
+                  vencimento: p.vencimento ?? null,
+              }))
+            : [];
+
+        return {
+            temporada,
+            status: inscricao.status ?? null,
+            taxa_inscricao: truncarPontosNum(inscricao.taxa_inscricao ?? 0),
+            pagou_inscricao: !!inscricao.pagou_inscricao,
+            saldo_inicial_temporada: truncarPontosNum(inscricao.saldo_inicial_temporada ?? 0),
+            saldo_transferido: truncarPontosNum(inscricao.saldo_transferido ?? 0),
+            parcelamento: parcelas.length
+                ? { total_parcelas: parcelas.length, parcelas }
+                : null,
+        };
+    },
+};

--- a/services/ia/tools/pontuacaoRodada.js
+++ b/services/ia/tools/pontuacaoRodada.js
@@ -1,0 +1,98 @@
+/**
+ * TOOL: pontuacao_rodada
+ *
+ * Retorna a pontuacao do participante logado em uma rodada especifica.
+ * Sem argumento: retorna a rodada consolidada mais recente.
+ * Com rodada: retorna os dados daquela rodada.
+ *
+ * Inclui: pontos, posicao no ranking, escalacao resumida (atleta + pontos)
+ * e capitao. Multi-tenant: ligaId vem do ctx.
+ */
+
+import { filtroLiga, toObjectId } from '../mongoHelpers.js';
+import { truncarPontosNum } from '../../../utils/type-helpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+export default {
+    name: 'pontuacao_rodada',
+    description:
+        'Retorna a pontuacao do participante logado em uma rodada especifica: pontos, posicao no ranking, escalacao (atletas + pontos) e capitao. Sem rodada especificada, retorna a rodada consolidada mais recente. Use quando perguntarem "quantos pontos fiz na rodada X", "minha escalacao na rodada X", "qual foi minha melhor rodada", "como fui na rodada passada".',
+    parameters: {
+        type: 'object',
+        properties: {
+            rodada: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 38,
+                description:
+                    'Numero da rodada. Omitir para retornar a rodada consolidada mais recente.',
+            },
+        },
+        additionalProperties: false,
+    },
+
+    async handler({ args, ctx, db }) {
+        const filtroBase = filtroLiga('rodadas', ctx.ligaId);
+        if (!filtroBase) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+        const timeId = Number(ctx.timeId);
+
+        // Se nao foi passada rodada, buscar a mais recente consolidada para o usuario
+        let rodadaNum = args?.rodada ? Number(args.rodada) : null;
+
+        if (!rodadaNum) {
+            const ultimo = await db
+                .collection('rodadas')
+                .findOne(
+                    { ...filtroBase, timeId, temporada, pontos: { $gt: 0 } },
+                    { sort: { rodada: -1 }, projection: { rodada: 1 } }
+                );
+            if (!ultimo) {
+                return {
+                    mensagem: 'Ainda nao ha rodadas consolidadas para voce nesta liga.',
+                    rodadas_disponiveis: 0,
+                };
+            }
+            rodadaNum = ultimo.rodada;
+        }
+
+        // Buscar o documento do usuario nessa rodada
+        const doc = await db.collection('rodadas').findOne({
+            ...filtroBase,
+            timeId,
+            rodada: rodadaNum,
+            temporada,
+        });
+
+        if (!doc) {
+            return {
+                rodada: rodadaNum,
+                mensagem: `Nao ha dados para voce na rodada ${rodadaNum}. Talvez voce nao estivesse na liga nessa rodada.`,
+            };
+        }
+
+        // Buscar total de participantes nessa rodada para calcular posicao
+        const totalParticipantes = await db
+            .collection('rodadas')
+            .countDocuments({ ...filtroBase, rodada: rodadaNum, temporada });
+
+        // Escalacao resumida
+        const atletas = (doc.atletas || []).map(a => ({
+            apelido: a.apelido || null,
+            posicao_id: a.posicao_id || null,
+            pontos: truncarPontosNum(a.pontos_num ?? 0),
+            capitao: a.atleta_id === doc.capitao_id,
+        }));
+
+        return {
+            rodada: doc.rodada,
+            pontos: truncarPontosNum(doc.pontos ?? 0),
+            posicao: doc.posicao ?? null,
+            total_participantes: doc.totalParticipantesAtivos ?? totalParticipantes,
+            rodada_nao_jogada: !!doc.rodadaNaoJogada,
+            atletas,
+            capitao_id: doc.capitao_id ?? null,
+        };
+    },
+};

--- a/services/ia/tools/rankingRodada.js
+++ b/services/ia/tools/rankingRodada.js
@@ -1,0 +1,93 @@
+/**
+ * TOOL: ranking_rodada
+ *
+ * Retorna o ranking de pontuacao de uma rodada especifica:
+ * top-5 cartoleiros + lanterna (ultimo colocado).
+ * Sem rodada: usa a mais recente consolidada.
+ *
+ * Multi-tenant: ligaId vem do ctx.
+ */
+
+import { filtroLiga } from '../mongoHelpers.js';
+import { truncarPontosNum } from '../../../utils/type-helpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+export default {
+    name: 'ranking_rodada',
+    description:
+        'Retorna o ranking de pontuacao de uma rodada: top-5 cartoleiros (mitos) e o lanterna (mico) da rodada. Sem rodada especificada, usa a mais recente consolidada. Use quando perguntarem "quem foi o cartoleiro da rodada X", "quem pontuou mais na rodada X", "quem foi o mico da rodada", "ranking da rodada".',
+    parameters: {
+        type: 'object',
+        properties: {
+            rodada: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 38,
+                description:
+                    'Numero da rodada. Omitir para usar a rodada consolidada mais recente.',
+            },
+        },
+        additionalProperties: false,
+    },
+
+    async handler({ args, ctx, db }) {
+        const filtroBase = filtroLiga('rodadas', ctx.ligaId);
+        if (!filtroBase) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+
+        // Determinar rodada
+        let rodadaNum = args?.rodada ? Number(args.rodada) : null;
+
+        if (!rodadaNum) {
+            const ultimo = await db
+                .collection('rodadas')
+                .findOne(
+                    { ...filtroBase, temporada, pontos: { $gt: 0 } },
+                    { sort: { rodada: -1 }, projection: { rodada: 1 } }
+                );
+            if (!ultimo) {
+                return { mensagem: 'Ainda nao ha rodadas consolidadas nesta liga.' };
+            }
+            rodadaNum = ultimo.rodada;
+        }
+
+        const docs = await db
+            .collection('rodadas')
+            .find({ ...filtroBase, rodada: rodadaNum, temporada })
+            .sort({ pontos: -1 })
+            .toArray();
+
+        if (!docs.length) {
+            return {
+                rodada: rodadaNum,
+                mensagem: `Nao ha dados para a rodada ${rodadaNum}.`,
+            };
+        }
+
+        const mapParticipante = (d, pos) => ({
+            posicao: pos,
+            nome_cartola: d.nome_cartola || null,
+            nome_time: d.nome_time || null,
+            pontos: truncarPontosNum(d.pontos ?? 0),
+            meu_time: Number(d.timeId) === Number(ctx.timeId),
+        });
+
+        const top5 = docs.slice(0, 5).map((d, i) => mapParticipante(d, i + 1));
+        const lanterna = docs.length > 5 ? mapParticipante(docs[docs.length - 1], docs.length) : null;
+
+        // Posicao do usuario logado (se nao estiver no top-5)
+        const euIdx = docs.findIndex(d => Number(d.timeId) === Number(ctx.timeId));
+        const eu = euIdx >= 0 && euIdx >= 5
+            ? mapParticipante(docs[euIdx], euIdx + 1)
+            : null;
+
+        return {
+            rodada: rodadaNum,
+            total_participantes: docs.length,
+            top_5: top5,
+            lanterna,
+            minha_posicao: eu,
+        };
+    },
+};

--- a/services/ia/tools/regraDeModulo.js
+++ b/services/ia/tools/regraDeModulo.js
@@ -4,11 +4,16 @@
  * Retorna a regra textual de um modulo, lendo diretamente os arquivos
  * JSON em /config/rules/. Substitui o RAG antigo — volume pequeno e
  * leitura direta e mais simples e determinista.
+ *
+ * v2: cruza a regra estatica com as configuracoes customizadas da liga
+ * (ModuleConfig.wizard_respostas), devolvendo overrides especificos da liga.
  */
 
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { filtroLiga } from '../mongoHelpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -67,7 +72,7 @@ export default {
         additionalProperties: false,
     },
 
-    async handler({ args }) {
+    async handler({ args, ctx, db }) {
         const chave = normalizar(args?.modulo);
         const arquivo = MAPA[chave];
 
@@ -80,25 +85,64 @@ export default {
             };
         }
 
+        // Regra estatica do JSON
+        let regraEstatica = {};
         try {
             const caminho = path.join(RULES_DIR, arquivo);
             const raw = fs.readFileSync(caminho, 'utf-8');
-            const json = JSON.parse(raw);
-
-            return {
-                modulo: json.nome || chave,
-                descricao: json.descricao || null,
-                regras: json.regras || null,
-                pontuacao: json.pontuacao || null,
-                premiacao: json.premiacao || null,
-                observacoes: json.observacoes || null,
-                arquivo_fonte: arquivo,
-            };
+            regraEstatica = JSON.parse(raw);
         } catch (error) {
             return {
                 erro: 'arquivo_ilegivel',
                 detalhe: error.message,
             };
         }
+
+        // Overrides per-liga via ModuleConfig.wizard_respostas
+        let wizardRespostas = null;
+        if (ctx?.ligaId && db) {
+            try {
+                const filtroMod = filtroLiga('moduleconfigs', ctx.ligaId);
+                if (filtroMod) {
+                    const temporada = Number(ctx.temporada || CURRENT_SEASON);
+                    // Mapear chave normalizada -> nome do modulo no moduleconfigs
+                    const MAPA_MODULO = {
+                        pontos_corridos: 'pontos_corridos', pontoscorridos: 'pontos_corridos',
+                        mata_mata: 'mata_mata', matamata: 'mata_mata',
+                        top_10: 'top10', top10: 'top10',
+                        melhor_mes: 'melhor_mes', melhormes: 'melhor_mes',
+                        ranking_geral: 'ranking_geral', ranking: 'ranking_geral',
+                        turno_returno: 'turno_returno', turnoreturno: 'turno_returno',
+                        resta_um: 'resta_um', restaum: 'resta_um',
+                        tiro_certo: 'tiro_certo', tirocerto: 'tiro_certo',
+                        artilheiro: 'artilheiro',
+                        capitao_luxo: 'capitao_luxo', capitaoluxo: 'capitao_luxo',
+                        luva_ouro: 'luva_ouro', luvaouro: 'luva_ouro',
+                    };
+                    const nomeModulo = MAPA_MODULO[chave];
+                    if (nomeModulo) {
+                        const mc = await db
+                            .collection('moduleconfigs')
+                            .findOne(
+                                { ...filtroMod, modulo: nomeModulo, temporada },
+                                { projection: { wizard_respostas: 1 } }
+                            );
+                        if (mc?.wizard_respostas && Object.keys(mc.wizard_respostas).length > 0) {
+                            wizardRespostas = mc.wizard_respostas;
+                        }
+                    }
+                }
+            } catch { /* fallback silencioso */ }
+        }
+
+        return {
+            modulo: regraEstatica.nome || chave,
+            descricao: regraEstatica.descricao || null,
+            regras: regraEstatica.regras || null,
+            pontuacao: regraEstatica.pontuacao || null,
+            premiacao: regraEstatica.premiacao || null,
+            observacoes: regraEstatica.observacoes || null,
+            configuracoes_desta_liga: wizardRespostas,
+        };
     },
 };

--- a/services/ia/tools/regrasLigaGerais.js
+++ b/services/ia/tools/regrasLigaGerais.js
@@ -1,0 +1,67 @@
+/**
+ * TOOL: regras_liga_gerais
+ *
+ * Retorna as regras configuradas pelo administrador da liga:
+ * taxa de inscricao, parcelamento, prazo de renovacao, permissoes
+ * (devedor pode renovar, aproveitar credito, etc.).
+ *
+ * Consome `ligarules` (liga_id ObjectId). Sem module check —
+ * e um dado da liga sempre disponivel.
+ * Multi-tenant: ligaId vem do ctx.
+ */
+
+import { filtroLiga } from '../mongoHelpers.js';
+import { truncarPontosNum } from '../../../utils/type-helpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+export default {
+    name: 'regras_liga_gerais',
+    description:
+        'Retorna as regras gerais da liga configuradas pelo admin: taxa de inscricao, parcelamento, prazo de renovacao, permissoes (devedor pode renovar, credito anterior pode ser usado). Use quando perguntarem "qual a taxa da liga", "posso parcelar a inscricao", "quando e o prazo", "quais as regras da liga", "posso entrar devendo".',
+    parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+    },
+
+    async handler({ ctx, db }) {
+        const filtro = filtroLiga('ligarules', ctx.ligaId);
+        if (!filtro) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+
+        const regras = await db
+            .collection('ligarules')
+            .findOne({ ...filtro, temporada });
+
+        if (!regras) {
+            return {
+                mensagem: 'Nao ha regras configuradas para esta liga nesta temporada.',
+                temporada,
+            };
+        }
+
+        const insc = regras.inscricao || {};
+
+        // Parcelamento
+        const parcOpcoes = Array.isArray(insc.parcelamento?.opcoes)
+            ? insc.parcelamento.opcoes.map(o => ({
+                  parcelas: o.parcelas,
+                  descricao: o.descricao ?? null,
+              }))
+            : [];
+
+        return {
+            temporada,
+            inscricao: {
+                taxa: truncarPontosNum(insc.taxa ?? 0),
+                prazo_renovacao: insc.prazo_renovacao ?? null,
+                parcelamento_permitido: !!insc.parcelamento?.permitir,
+                opcoes_parcelamento: parcOpcoes,
+                devedor_pode_renovar: !!insc.permitir_devedor_renovar,
+                aproveitar_credito_anterior: !!insc.aproveitar_saldo_positivo,
+                gerar_debito_inscricao: insc.gerar_debito_inscricao_renovacao !== false,
+            },
+        };
+    },
+};

--- a/services/ia/tools/tiroCertoStatus.js
+++ b/services/ia/tools/tiroCertoStatus.js
@@ -1,0 +1,122 @@
+/**
+ * TOOL: tiro_certo_status
+ *
+ * Retorna o status do participante logado no modulo Tiro Certo:
+ * - Status (vivo, eliminado, campeao)
+ * - Rodadas sobrevividas
+ * - Ultimas 3 escolhas com resultado
+ * - Ranking de sobreviventes (quantos vivos restam + posicao no ranking de resistencia)
+ *
+ * Busca a edicao mais recente em andamento ou, se nenhuma ativa, a ultima finalizada.
+ * Verifica Liga.modulos_ativos.tiroCerto. Multi-tenant: ligaId vem do ctx.
+ */
+
+import { filtroLiga } from '../mongoHelpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+async function moduloAtivo(db, ligaId) {
+    const filtro = filtroLiga('ligas', ligaId);
+    if (!filtro) return false;
+    const liga = await db
+        .collection('ligas')
+        .findOne(filtro, { projection: { modulos_ativos: 1 } });
+    return liga?.modulos_ativos?.tiroCerto === true;
+}
+
+export default {
+    name: 'tiro_certo_status',
+    description:
+        'Retorna o status do participante logado no Tiro Certo: se esta vivo, eliminado ou campeao; rodadas sobrevividas; ultimas escolhas com resultado; e ranking de resistencia. Use quando perguntarem "como estou no tiro certo", "ainda estou vivo no tiro certo", "quantas rodadas sobrevivi", "qual minha escolha no tiro certo".',
+    parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+    },
+
+    async handler({ ctx, db }) {
+        const ativo = await moduloAtivo(db, ctx.ligaId);
+        if (!ativo) {
+            return {
+                modulo_ativo: false,
+                mensagem: 'O modulo Tiro Certo nao esta ativo nesta liga.',
+            };
+        }
+
+        const filtro = filtroLiga('tirocertocaches', ctx.ligaId);
+        if (!filtro) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+        const timeId = Number(ctx.timeId);
+
+        // Buscar edicao em andamento; fallback para a mais recente (finalizada ou pendente)
+        let edicao = await db
+            .collection('tirocertocaches')
+            .findOne({ ...filtro, temporada, status: 'em_andamento' }, { sort: { edicao: -1 } });
+
+        if (!edicao) {
+            edicao = await db
+                .collection('tirocertocaches')
+                .findOne({ ...filtro, temporada }, { sort: { edicao: -1 } });
+        }
+
+        if (!edicao) {
+            return {
+                modulo_ativo: true,
+                mensagem: 'Ainda nao ha edicao de Tiro Certo para esta liga.',
+            };
+        }
+
+        const participantes = Array.isArray(edicao.participantes) ? edicao.participantes : [];
+        const eu = participantes.find(p => Number(p.timeId) === timeId);
+
+        if (!eu) {
+            return {
+                modulo_ativo: true,
+                edicao: edicao.edicao,
+                nome: edicao.nome,
+                status_edicao: edicao.status,
+                mensagem: 'Voce nao esta inscrito nesta edicao do Tiro Certo.',
+            };
+        }
+
+        // Ultimas 3 escolhas, da mais recente para a mais antiga
+        const escolhas = (eu.escolhas || [])
+            .slice()
+            .sort((a, b) => b.rodada - a.rodada)
+            .slice(0, 3)
+            .map(e => ({
+                rodada: e.rodada,
+                time_escolhido: e.timeEscolhidoNome || null,
+                adversario: e.adversarioNome || null,
+                resultado: e.resultado,
+                placar: e.placarMandante != null && e.placarVisitante != null
+                    ? `${e.placarMandante}x${e.placarVisitante}`
+                    : null,
+            }));
+
+        // Ranking de sobrevivencia: ordenar por rodadasSobrevividas desc
+        const rankingSobrevivencia = participantes
+            .filter(p => p.status === 'vivo' || p.status === 'campeao')
+            .sort((a, b) => b.rodadasSobrevividas - a.rodadasSobrevividas);
+
+        const minhaPosicaoVivos = rankingSobrevivencia.findIndex(p => Number(p.timeId) === timeId);
+
+        return {
+            modulo_ativo: true,
+            edicao: edicao.edicao,
+            nome: edicao.nome,
+            status_edicao: edicao.status,
+            rodada_atual: edicao.rodadaAtual ?? null,
+            vivos_restantes: edicao.vivosCount ?? rankingSobrevivencia.length,
+            total_participantes: participantes.length,
+            meu_status: {
+                status: eu.status,
+                rodadas_sobrevividas: eu.rodadasSobrevividas ?? 0,
+                posicao_resistencia: minhaPosicaoVivos >= 0 ? minhaPosicaoVivos + 1 : null,
+                rodada_eliminacao: eu.rodadaEliminacao ?? null,
+                motivo_eliminacao: eu.motivoEliminacao ?? null,
+            },
+            ultimas_escolhas: escolhas,
+        };
+    },
+};

--- a/services/ia/tools/topDezMitosMicos.js
+++ b/services/ia/tools/topDezMitosMicos.js
@@ -1,0 +1,77 @@
+/**
+ * TOOL: top_dez_mitos_micos
+ *
+ * Retorna os top-10 mitos (maiores pontuadores) e top-10 micos (menores
+ * pontuadores) da rodada mais recente ou de uma rodada especifica.
+ *
+ * Consome `top10caches` (liga_id String). Multi-tenant: ligaId vem do ctx.
+ */
+
+import { filtroLiga } from '../mongoHelpers.js';
+import { truncarPontosNum } from '../../../utils/type-helpers.js';
+import { CURRENT_SEASON } from '../../../config/seasons.js';
+
+export default {
+    name: 'top_dez_mitos_micos',
+    description:
+        'Retorna os top-10 mitos (maiores pontuadores) e top-10 micos (menores pontuadores) da rodada. Sem rodada especificada, usa a mais recente consolidada. Use quando perguntarem "quem sao os mitos", "quem sao os micos", "top 10 da rodada", "quem pontuou mais/menos".',
+    parameters: {
+        type: 'object',
+        properties: {
+            rodada: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 38,
+                description:
+                    'Numero da rodada. Omitir para usar a rodada consolidada mais recente.',
+            },
+        },
+        additionalProperties: false,
+    },
+
+    async handler({ args, ctx, db }) {
+        const filtro = filtroLiga('top10caches', ctx.ligaId);
+        if (!filtro) return { erro: 'liga_invalida' };
+
+        const temporada = Number(ctx.temporada || CURRENT_SEASON);
+
+        let cache;
+        if (args?.rodada) {
+            cache = await db
+                .collection('top10caches')
+                .findOne({ ...filtro, rodada_consolidada: Number(args.rodada), temporada });
+        } else {
+            cache = await db
+                .collection('top10caches')
+                .findOne(
+                    { ...filtro, temporada },
+                    { sort: { rodada_consolidada: -1 } }
+                );
+        }
+
+        if (!cache) {
+            return {
+                mensagem: args?.rodada
+                    ? `Nao ha dados de top-10 para a rodada ${args.rodada}.`
+                    : 'Ainda nao ha dados de top-10 consolidados para esta liga.',
+            };
+        }
+
+        const mapItem = (item, pos) => ({
+            posicao: pos,
+            nome_cartola: item.nome_cartola || null,
+            nome_time: item.nome_time || null,
+            pontos: truncarPontosNum(item.pontos ?? 0),
+            meu_time: Number(item.timeId) === Number(ctx.timeId),
+        });
+
+        const mitos = (cache.mitos || []).map((m, i) => mapItem(m, i + 1));
+        const micos = (cache.micos || []).map((m, i) => mapItem(m, i + 1));
+
+        return {
+            rodada: cache.rodada_consolidada,
+            mitos,
+            micos,
+        };
+    },
+};


### PR DESCRIPTION
## Resumo

Continuação do Big Cartola IA após a Fase 1 (PR #65). Adiciona 11 tools novas, expande 1 existente e entrega os chips de sugestão na UI.

### Fase 2 — Desempenho por rodada + mata-mata + top 10 (6 tools)
- `pontuacao_rodada`: pontos + escalação do usuário em qualquer rodada
- `ranking_rodada`: top-5 cartoleiros + lanterna de uma rodada
- `mata_mata_situacao`: todas as edições com confronto ativo enfatizado
- `top_dez_mitos_micos`: mitos e micos por rodada (top10caches)
- `tiro_certo_status`: status no Survival + últimas escolhas
- `goleiros_top`: ranking defensivo por rodada (complementa luva_de_ouro)

### Fase 3 — Financeiro detalhado + config + jogos (5 tools + 1 expansão)
- `meu_extrato_detalhado`: histórico itemizado de rodadas + ajustes manuais
- `minhas_inscricoes`: taxa, status, pagou, parcelamento da temporada
- `config_liga_detalhada`: Liga.configuracoes + ModuleConfig.wizard_respostas
- `regras_liga_gerais`: taxa/prazo/parcelamento de LigaRules
- `jogos_do_dia`: fixtures do dia via api-orchestrator
- `regra_de_modulo` *(expandido)*: cruza JSON estático com wizard_respostas per-liga

### Fase 4 — UX
- `participante-chatbot.js`: SUGESTOES_POR_MODULO expandido com 7 módulos novos (melhorMes, mataMata, top10, tiroCerto, luvaOuro, artilheiro, capitaoLuxo) + 2 sugestões universais novas
- MAP_ID atualizado para todos os novos módulos

### Infra
- `mongoHelpers.js`: 6 coleções novas no LIGA_ID_FORMAT (fix silencioso: `matamatacaches` retornava null)
- `toolRegistry.js`: 11 tools registradas
- `chatbotService.js`: 11 entradas no GUIA DE DESAMBIGUACAO do SYSTEM_PROMPT_BASE

## Test plan
- [ ] Testar pergunta "quantos pontos fiz na última rodada?" → `pontuacao_rodada`
- [ ] Testar "quem foi o cartoleiro da rodada?" → `ranking_rodada`
- [ ] Testar "minha chave no mata-mata?" → `mata_mata_situacao`
- [ ] Testar "quem são os mitos e micos?" → `top_dez_mitos_micos`
- [ ] Testar "ainda estou vivo no tiro certo?" → `tiro_certo_status`
- [ ] Testar "meu extrato detalhado" → `meu_extrato_detalhado`
- [ ] Testar "tem jogo hoje?" → `jogos_do_dia`
- [ ] Verificar chips de sugestão aparecem ao abrir chatbot
- [ ] Verificar zero HTTP 500 nos logs `[IA-CHATBOT]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)