### PR TITLE
fix(parciais): bloquear reserva quando partida do titular ainda em pré-jogo

### DIFF
--- a/controllers/parciaisController.js
+++ b/controllers/parciaisController.js
@@ -42,10 +42,37 @@ async function fetchCartola(url) {
 async function buscarAtletasPontuados() {
   try {
     const data = await fetchCartola(`${CARTOLA_API_BASE}/atletas/pontuados`);
-    return data?.atletas || {};
+    return {
+      atletas: data?.atletas || {},
+      partidas: data?.partidas || {},
+    };
   } catch {
-    return {};
+    return { atletas: {}, partidas: {} };
   }
+}
+
+/**
+ * Mapeia clube_id → estado da partida ('pre' | 'liveOrEnded').
+ * Reserva só substitui titular quando a partida do titular já saiu do pré-jogo
+ * (caso contrário o titular ainda pode entrar em campo).
+ * Fallback conservador: clube ausente do mapa = 'pre' (não substitui).
+ */
+function mapearStatusClubes(partidasInfo) {
+  const mapa = {};
+  if (!partidasInfo) return mapa;
+
+  const partidas = Array.isArray(partidasInfo) ? partidasInfo : Object.values(partidasInfo);
+  const PRE_REGEX = /pré|pre-?jogo|aguard|preliminar/i;
+
+  for (const p of partidas) {
+    if (!p) continue;
+    const status = p.status_cronometro_tr || p.status_partida || '';
+    const ehPre = !status || PRE_REGEX.test(status);
+    const estado = ehPre ? 'pre' : 'liveOrEnded';
+    if (p.clube_casa_id) mapa[p.clube_casa_id] = estado;
+    if (p.clube_visitante_id) mapa[p.clube_visitante_id] = estado;
+  }
+  return mapa;
 }
 
 async function buscarEscalacao(timeId, rodada) {
@@ -69,7 +96,7 @@ async function buscarEscalacao(timeId, rodada) {
 //         reserva de luxo: Cenário A (ausente) ou Cenário B (pior titular)
 // ──────────────────────────────────────────────────────────────────────────────
 
-function calcularPontuacao(dadosEscalacao, atletasPontuados, time) {
+function calcularPontuacao(dadosEscalacao, atletasPontuados, time, statusPorClube = {}) {
   if (!dadosEscalacao?.atletas?.length) {
     return _timeVazio(time, true);
   }
@@ -114,13 +141,14 @@ function calcularPontuacao(dadosEscalacao, atletasPontuados, time) {
   });
 
   // ── FASE 2: Mapear ausentes por posição ──
-  // Titular é ausente quando NÃO confirmou entrou_em_campo_real E tem pontos = 0.
-  // Guardar pontos === 0 evita dupla-contagem: se titular pontuou mas entrou_em_campo
-  // ainda é null (API atrasada), ele JÁ foi contabilizado na Fase 1 e não pode ser
-  // substituído ao mesmo tempo.
+  // Titular é ausente quando: NÃO confirmou entrou_em_campo_real E pontos = 0
+  // E partida do clube dele já saiu do pré-jogo (caso contrário ele ainda pode jogar
+  // e o reserva NÃO deve substituir antecipadamente). Fallback: status desconhecido
+  // = pré-jogo (conservador, evita pagar reserva indevida em caso de falha de dados).
   const ausentesPorPosicao = {};
   titularesProcessados.forEach((t) => {
-    if (!t.entrou_em_campo_real && t.pontos === 0) {
+    const partidaJaComecou = statusPorClube[t.clube_id] === 'liveOrEnded';
+    if (!t.entrou_em_campo_real && t.pontos === 0 && partidaJaComecou) {
       if (!ausentesPorPosicao[t.posicao_id]) ausentesPorPosicao[t.posicao_id] = [];
       ausentesPorPosicao[t.posicao_id].push(t);
     }
@@ -387,10 +415,13 @@ export async function getParciais(req, res) {
     console.log(`[PARCIAIS-CTRL] Liga ${ligaId}: ativos=${timesAtivos.length}, inativos=${timesInativosArr.length}`);
 
     // 3. Scouts: frozen (MongoDB) + live (API Cartola)
-    const [scoutsFrozen, atletasLive] = await Promise.all([
+    const [scoutsFrozen, dadosLive] = await Promise.all([
       scoutSnapshotService.buscarScoutsFrozen(rodadaAtual),
       buscarAtletasPontuados(),
     ]);
+    const atletasLive = dadosLive.atletas;
+    const partidasInfo = dadosLive.partidas;
+    const statusPorClube = mapearStatusClubes(partidasInfo);
 
     // Persistência assíncrona (não bloqueia resposta)
     if (Object.keys(atletasLive).length > 0) {
@@ -416,7 +447,7 @@ export async function getParciais(req, res) {
           const time = timesAtivos[idx++];
           ativos++;
           buscarEscalacao(time.timeId, rodadaAtual)
-            .then((esc) => resultados.push(esc ? calcularPontuacao(esc, atletasPontuados, time) : _timeVazio(time, true)))
+            .then((esc) => resultados.push(esc ? calcularPontuacao(esc, atletasPontuados, time, statusPorClube) : _timeVazio(time, true)))
             .catch(() => resultados.push(_timeVazio(time, true)))
             .finally(() => {
               ativos--;

--- a/services/parciaisRankingService.js
+++ b/services/parciaisRankingService.js
@@ -122,11 +122,36 @@ async function buscarEscalacaoTime(timeId, rodada) {
 }
 
 /**
+ * Mapeia clube_id → estado da partida ('pre' | 'liveOrEnded').
+ * Reserva só substitui titular quando a partida do titular já saiu do pré-jogo
+ * (caso contrário o titular ainda pode entrar em campo).
+ * Fallback conservador: clube ausente do mapa = 'pre' (não substitui).
+ */
+function mapearStatusClubes(partidasInfo) {
+    const mapa = {};
+    if (!partidasInfo) return mapa;
+
+    const partidas = Array.isArray(partidasInfo) ? partidasInfo : Object.values(partidasInfo);
+    const PRE_REGEX = /pré|pre-?jogo|aguard|preliminar/i;
+
+    for (const p of partidas) {
+        if (!p) continue;
+        const status = p.status_cronometro_tr || p.status_partida || '';
+        const ehPre = !status || PRE_REGEX.test(status);
+        const estado = ehPre ? 'pre' : 'liveOrEnded';
+        if (p.clube_casa_id) mapa[p.clube_casa_id] = estado;
+        if (p.clube_visitante_id) mapa[p.clube_visitante_id] = estado;
+    }
+    return mapa;
+}
+
+/**
  * Calcula pontuação de um time baseado na escalação e atletas pontuados.
  * ✅ v2.0: Lógica completa com reservas comuns + reserva de luxo
  *          (porta fiel de parciaisController.js::calcularPontuacao)
+ * ✅ v2.1: statusPorClube bloqueia substituição de titular cuja partida ainda não começou
  */
-function calcularPontuacaoTime(escalacao, atletasPontuados) {
+function calcularPontuacaoTime(escalacao, atletasPontuados, statusPorClube = {}) {
     if (!escalacao || !escalacao.atletas || escalacao.atletas.length === 0) {
         return { pontos: 0, calculado: false, atletasEmCampo: 0, totalAtletas: 0 };
     }
@@ -155,6 +180,7 @@ function calcularPontuacaoTime(escalacao, atletasPontuados) {
         titularesProcessados.push({
             atleta_id: atletaId,
             posicao_id: atleta.posicao_id,
+            clube_id: atleta.clube_id || ap?.clube_id || null,
             pontos: pontuacao,
             pontos_efetivos: pontosEfetivos,
             entrou_em_campo: jogou,
@@ -164,12 +190,15 @@ function calcularPontuacaoTime(escalacao, atletasPontuados) {
     }
 
     // ── FASE 2: Mapear ausentes por posição ──
-    // Titular é ausente quando NÃO confirmou entrou_em_campo_real E tem pontos = 0.
-    // Guard pontos === 0 evita dupla-contagem: titular que pontuou mas ainda sem
-    // entrou_em_campo confirmado (API lag) já foi contabilizado na Fase 1.
+    // Titular é ausente quando: NÃO confirmou entrou_em_campo_real E pontos = 0
+    // E partida do clube dele já saiu do pré-jogo (caso contrário ele ainda pode jogar
+    // e o reserva NÃO deve substituir antecipadamente). Fallback: status desconhecido
+    // = pré-jogo (conservador, evita pagar reserva indevida em caso de falha de dados).
     const ausentesPorPosicao = {};
     for (const t of titularesProcessados) {
-        if (!t.entrou_em_campo_real && t.pontos === 0) {
+        const statusClube = statusPorClube[t.clube_id];
+        const partidaJaComecou = statusClube === 'liveOrEnded';
+        if (!t.entrou_em_campo_real && t.pontos === 0 && partidaJaComecou) {
             if (!ausentesPorPosicao[t.posicao_id]) ausentesPorPosicao[t.posicao_id] = [];
             ausentesPorPosicao[t.posicao_id].push(t);
         }
@@ -282,11 +311,12 @@ export async function buscarRankingParcial(ligaId) {
         // Frozen tem prioridade: dados definitivos do banco sobrescrevem a API live
         const atletasPontuados = { ...dadosApi.atletas, ...scoutsFrozen };
         const partidasInfo = dadosApi.partidas;
+        const statusPorClube = mapearStatusClubes(partidasInfo);
         const numAtletasPontuados = Object.keys(atletasPontuados).length;
         const numFrozen = Object.keys(scoutsFrozen).length;
 
         console.debug(`${LOG_PREFIX} Atletas pontuados: ${numAtletasPontuados} (${numFrozen} frozen)`);
-        console.debug(`${LOG_PREFIX} Partidas da rodada: ${Object.keys(partidasInfo).length}`);
+        console.debug(`${LOG_PREFIX} Partidas da rodada: ${Object.keys(partidasInfo).length} (${Object.keys(statusPorClube).length} clubes mapeados)`);
 
         // Persistência assíncrona (não bloqueia resposta)
         if (Object.keys(dadosApi.atletas).length > 0) {
@@ -398,7 +428,7 @@ export async function buscarRankingParcial(ligaId) {
 
                 if (escalacao) {
                     // API respondeu: calcular pontos via atletas pontuados
-                    ({ pontos, calculado, atletasEmCampo, totalAtletas } = calcularPontuacaoTime(escalacao, atletasPontuados));
+                    ({ pontos, calculado, atletasEmCampo, totalAtletas } = calcularPontuacaoTime(escalacao, atletasPontuados, statusPorClube));
                 } else {
                     // ✅ v1.4: API falhou — usar fallback do banco de dados
                     const fallback = fallbackRodadaMap.get(participante.time_id);


### PR DESCRIPTION
Antes: titular com `entrou_em_campo !== true` e pontos = 0 era marcado como
ausente independentemente do status do jogo do clube dele. Reserva (que já
jogou) substituía o titular antecipadamente, somando pontos na parcial mesmo
com o titular ainda podendo entrar em campo.

Agora: cruza com `partidasInfo` (já disponível em /atletas/pontuados) para
construir mapa clube_id → status. Titular só é marcado como ausente se a
partida do clube dele já saiu do pré-jogo. Fallback conservador (status
desconhecido = pré-jogo) preserva titular zerado em vez de pagar reserva
indevida.

Aplicado em ambos os calculadores:
- services/parciaisRankingService.js::calcularPontuacaoTime
- controllers/parciaisController.js::calcularPontuacao