### PR TITLE
docs(mcp): documentar reativação do Mongo MCP em nova sessão CCW

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,16 @@ Ferramentas: `list_collections`, `find_documents`, `get_collection_schema`, `ins
 Container: `scm-mcp` (Docker, porta 3099 interna). Antes de qualquer código que toque dados → consultar este MCP.
 Token e URL completa: ver `MCP_SECRET_TOKEN` no `.env.prod` da VPS.
 
+**Reativar Mongo MCP em nova sessão CCW (sandbox limpo):**
+`.mcp.json` está no `.gitignore` — cada sandbox novo precisa recriar. Procedimento:
+1. Obter token na VPS: `ssh vps 'grep MCP_SECRET_TOKEN /var/www/cartola/.env.prod | cut -d= -f2-'`
+2. Copiar `.mcp.json.example` → `.mcp.json` e manter SÓ o bloco `mongo-remote` (URL `https://supercartolamanager.com.br/mcp-mongo/mcp` + header `x-mcp-token: <token>`)
+3. Validar antes de reiniciar: `curl -sS -i -H "x-mcp-token: <TOKEN>" -H "Accept: application/json, text/event-stream" -X POST https://supercartolamanager.com.br/mcp-mongo/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"diag","version":"0.1"}}}'` — esperado: HTTP 200 + header `mcp-session-id`
+4. Reiniciar a sessão CCW (`.mcp.json` é lido só na inicialização, não em hot-reload)
+5. Confirmar: rodar `/mcp` na nova sessão → `mongo-remote ✓ connected`
+
+Diagnóstico rápido: `GET /mcp-mongo/health` (sem auth) → `{"status":"ok","sessions":N}` indica container vivo.
+
 ## Pontos Corridos (REGRA CRÍTICA)
 
 Liga com número **ímpar** de times usa sistema de BYE: um time folga por rodada, rotacionando deterministicamente. Time com BYE: `jogos` NÃO é incrementado, pontos/financeiro não alteram.


### PR DESCRIPTION
## Contexto

Em sessões novas do Claude Code Web, o Mongo MCP costuma "sumir" porque `.mcp.json` está no `.gitignore` (linha 19) e cada sandbox limpo precisa recriar o arquivo. Isso travou esta própria sessão até a investigação revelar a causa raiz. Esta PR documenta o procedimento canônico para que futuras sessões resolvam em 1 minuto.

## Mudança

Adiciona subseção **"Reativar Mongo MCP em nova sessão CCW (sandbox limpo)"** sob `## MCPs Disponíveis` no `CLAUDE.md` (10 linhas, +0 -0 fora desse bloco):

1. Como obter o token na VPS (`ssh vps 'grep MCP_SECRET_TOKEN ...'`)
2. Como recriar `.mcp.json` a partir do `.example` (manter só `mongo-remote`)
3. Curl `initialize` para validar token+endpoint **antes** do reinício (evita ciclo "reinicia, falha, descobre o erro")
4. Reiniciar sessão CCW (`.mcp.json` é lido só na inicialização)
5. Confirmar com `/mcp`

Mais o atalho de diagnóstico: `GET /mcp-mongo/health` (sem auth) → status do container.

## Por que documentar

- `.mcp.json.example` mostra o **formato**, mas não o **procedimento end-to-end** (onde achar o token, como validar antes de gastar reinício, qual transporte usar)
- O fluxo `initialize` → `mcp-session-id` do StreamableHTTP não é óbvio — sem ele, `tools/list` cru retorna `400 Bad Request: sem session ID válido` e gera falso negativo
- Bloco fica em `CLAUDE.md` (versionado) para a skill `newsession` e qualquer Claude futuro encontrarem na inicialização

## Test plan

- [x] `git diff --stat CLAUDE.md` → 1 file changed, 10 insertions(+) — diff cirúrgico
- [x] Procedimento foi executado nesta sessão e funciona ponta-a-ponta (token validado HTTP 200, `mcp-session-id` retornado, `.mcp.json` criado, ignorado pelo git)
- [ ] Validação final: usuário reinicia sessão CCW e confirma `mongo-remote ✓ connected` em `/mcp` (pendente — depende da próxima sessão)

## Risco

Zero — só documentação. Nenhum código, config ou comportamento de runtime alterado.

https://claude.ai/code/session_01TsbU61y69qZ3LVRsMsG2EE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsbU61y69qZ3LVRsMsG2EE)_