### PR TITLE
feat(claude): auto-bootstrap Mongo MCP via SessionStart hook

### DIFF
--- a/.claude/hooks/session-start-mcp-bootstrap
+++ b/.claude/hooks/session-start-mcp-bootstrap
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SessionStart hook: auto-bootstrap .mcp.json a partir de $MCP_SECRET_TOKEN
+# Permite que sandboxes CCW (mobile, sem terminal) recuperem o Mongo MCP automaticamente.
+#
+# Comportamento:
+#   - .mcp.json já existe → no-op (não sobrescreve)
+#   - $MCP_SECRET_TOKEN ausente → log informativo e sai com 0
+#   - Token presente + arquivo ausente → escreve .mcp.json e avisa para reabrir sessão
+
+set -uo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+MCP_FILE="${PROJECT_DIR}/.mcp.json"
+MCP_URL="https://supercartolamanager.com.br/mcp-mongo/mcp"
+
+if [ -f "$MCP_FILE" ]; then
+  echo "🔌 Mongo MCP: .mcp.json ja existe (mantido)"
+  exit 0
+fi
+
+if [ -z "${MCP_SECRET_TOKEN:-}" ]; then
+  echo "🔌 Mongo MCP: \$MCP_SECRET_TOKEN nao definido - pulando bootstrap"
+  echo "   Para auto-conectar em sandboxes CCW novos, defina MCP_SECRET_TOKEN nas Environment Variables do CCW"
+  exit 0
+fi
+
+cat > "$MCP_FILE" <<EOF
+{
+  "mcpServers": {
+    "mongo-remote": {
+      "type": "http",
+      "url": "${MCP_URL}",
+      "headers": {
+        "x-mcp-token": "${MCP_SECRET_TOKEN}"
+      }
+    }
+  }
+}
+EOF
+
+echo "🔌 Mongo MCP: .mcp.json criado a partir de \$MCP_SECRET_TOKEN"
+echo "   ⚠️  Reabra a sessao CCW uma vez para o servidor mongo-remote conectar"

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -397,6 +397,11 @@
             "type": "command",
             "command": "bash .claude/hooks/session-start-planning-enforcer",
             "statusMessage": "Carregando protocolo de planejamento obrigatório..."
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session-start-mcp-bootstrap",
+            "statusMessage": "Verificando auto-bootstrap do Mongo MCP..."
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,15 @@ Container: `scm-mcp` (Docker, porta 3099 interna). Antes de qualquer código que
 Token e URL completa: ver `MCP_SECRET_TOKEN` no `.env.prod` da VPS.
 
 **Reativar Mongo MCP em nova sessão CCW (sandbox limpo):**
-`.mcp.json` está no `.gitignore` — cada sandbox novo precisa recriar. Procedimento:
+`.mcp.json` está no `.gitignore` — cada sandbox novo nasce sem ele.
+
+**Fluxo automático (preferido — funciona inclusive no CCW mobile sem terminal):**
+1. Setar UMA VEZ no CCW Settings → Environment Variables: `MCP_SECRET_TOKEN=<token_da_vps>`
+2. O hook `SessionStart` (`.claude/hooks/session-start-mcp-bootstrap`) detecta `.mcp.json` ausente + env var presente → cria o arquivo automaticamente
+3. Reabrir a sessão CCW UMA vez (MCP só é lido na inicialização)
+4. `/mcp` → `mongo-remote ✓ connected`
+
+**Fluxo manual (terminal disponível, ou primeira configuração da env var):**
 1. Obter token na VPS: `ssh vps 'grep MCP_SECRET_TOKEN /var/www/cartola/.env.prod | cut -d= -f2-'`
 2. Copiar `.mcp.json.example` → `.mcp.json` e manter SÓ o bloco `mongo-remote` (URL `https://supercartolamanager.com.br/mcp-mongo/mcp` + header `x-mcp-token: <token>`)
 3. Validar antes de reiniciar: `curl -sS -i -H "x-mcp-token: <TOKEN>" -H "Accept: application/json, text/event-stream" -X POST https://supercartolamanager.com.br/mcp-mongo/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"diag","version":"0.1"}}}'` — esperado: HTTP 200 + header `mcp-session-id`


### PR DESCRIPTION
## Contexto

Sandboxes CCW começam do zero — `.mcp.json` está no `.gitignore` e precisa ser recriado em cada sessão. No fluxo anterior, isso exigia `ssh vps` + edição manual do arquivo, o que **não funciona quando o usuário acessa o CCW pelo celular** (sem terminal).

## Solução

Hook `SessionStart` que cria `.mcp.json` automaticamente a partir da env var `MCP_SECRET_TOKEN` do CCW. Setado uma única vez nas Environment Variables do CCW, o token serve toda sessão futura sem ação manual.

## Mudanças

- **`.claude/hooks/session-start-mcp-bootstrap`** (novo): bash idempotente
  - `.mcp.json` existe → no-op
  - Sem `$MCP_SECRET_TOKEN` → log informativo, exit 0
  - Token + arquivo ausente → cria `.mcp.json` com bloco `mongo-remote` e avisa pra reabrir sessão
- **`.claude/settings.local.json`**: registra o novo hook em `SessionStart` (ao lado do `planning-enforcer` existente)
- **`CLAUDE.md` §Reativar Mongo MCP**: documenta fluxo automático como preferido + mantém o manual como fallback

## Testes locais (todos ✓)

- (a) `.mcp.json` existe → hook é no-op
- (b) sem env var + sem arquivo → log informativo, exit 0
- (c) com env var + sem arquivo → cria arquivo idêntico ao manual
- curl autenticado → HTTP 200 + `mcp-session-id` (servidor responde com `mongodb-server-http v1.0.0`)

## Test plan

- [ ] Setar `MCP_SECRET_TOKEN` em CCW Settings → Environment Variables (UI web, mobile-friendly)
- [ ] Abrir uma sandbox CCW nova → confirmar log "Mongo MCP: .mcp.json criado..." na inicialização
- [ ] Reabrir a sessão → `/mcp` mostra `mongo-remote ✓ connected`
- [ ] Smoke test funcional: chamar `mcp__mongo-remote__list_collections` retorna collections do banco `cartola-manager`

## Notas operacionais

- Token NÃO é commitado — vive só na env var do CCW e no `.mcp.json` (gitignored)
- Hook não bloqueia se env var ausente (continua funcionando em ambientes sem o secret)
- Cert SSL do `supercartolamanager.com.br` está rotacionando a cada ~13min (observado durante validação) — pode causar janelas curtas (0-30s) de falha SSL em clientes recém-iniciados; investigar `certbot.timer` na VPS quando der.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L13jhmsab7mfSZXncfrdcS)_