### PR TITLE
feat(extrato): redesign do extrato participante como ticket térmico

### DIFF
--- a/config/css-registry.json
+++ b/config/css-registry.json
@@ -303,9 +303,9 @@
         "description": "Tema Copa Super Cartola (dourado/trofeu)"
       },
       {
-        "path": "public/participante/css/extrato-bank.css",
+        "path": "public/participante/css/extrato-thermal.css",
         "loadedBy": ["participante/index.html"],
-        "description": "Extrato estilo banco digital (Nubank/Inter)"
+        "description": "Extrato financeiro estilo cupom de impressora termica (papel branco off-white, JetBrains Mono, asteriscos dividers, codigo de barras decorativo)"
       },
       {
         "path": "public/participante/css/pull-refresh.css",

--- a/public/participante/css/extrato-thermal.css
+++ b/public/participante/css/extrato-thermal.css
@@ -1,0 +1,458 @@
+/**
+ * EXTRATO TERMICO - CSS Module
+ * Estilo: ticket de impressora termica (papel branco off-white sobre dark).
+ * Tokens "thermal-*" sao locais e proposital (papel branco fixo, nao adapta ao tema dark).
+ * Tokens de tipografia (--app-font-*) e animacao (app-fade-in-up) reusados de _app-tokens.css.
+ * Substitui extrato-bank.css.
+ * Dependencia: _app-tokens.css (fonts + keyframe app-fade-in-up)
+ * Carregado por: public/participante/index.html
+ */
+
+.thermal-stage {
+    padding: 24px 12px 56px;
+    min-height: 100%;
+    background: radial-gradient(ellipse at top, transparent 0%, rgba(0, 0, 0, 0.35) 100%);
+}
+
+.thermal-ticket {
+    --thermal-paper: #FAFAF7;
+    --thermal-paper-highlight: #FFFDF5;
+    --thermal-ink: #1a1a1a;
+    --thermal-ink-soft: #4a4a4a;
+    --thermal-ink-dim: #9ca3af;
+    --thermal-ink-credit: #0d7a3f;
+    --thermal-ink-debit: #b91c1c;
+    --thermal-shadow:
+        0 24px 48px -12px rgba(0, 0, 0, 0.65),
+        0 12px 20px -6px rgba(0, 0, 0, 0.45),
+        inset 0 1px 0 rgba(255, 255, 255, 0.55);
+
+    position: relative;
+    width: calc(100% - 16px);
+    max-width: 380px;
+    margin: 16px auto;
+    padding: 30px 22px 24px;
+    background: var(--thermal-paper);
+    color: var(--thermal-ink);
+    font-family: var(--app-font-mono);
+    font-size: 13px;
+    line-height: 1.5;
+    box-shadow: var(--thermal-shadow);
+    opacity: 0;
+    animation: app-fade-in-up 0.4s ease-out 0.05s forwards;
+    content-visibility: auto;
+    contain-intrinsic-size: 100vh;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .thermal-ticket {
+        animation: none;
+        opacity: 1;
+    }
+}
+
+/* ===== Bordas zigzag (papel rasgado) ===== */
+.thermal-ticket__edge {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 10px;
+    background-image:
+        linear-gradient(135deg, var(--thermal-paper) 25%, transparent 25%),
+        linear-gradient(225deg, var(--thermal-paper) 25%, transparent 25%);
+    background-size: 16px 16px;
+    background-repeat: repeat-x;
+    pointer-events: none;
+}
+
+.thermal-ticket__edge--top {
+    top: -8px;
+    background-position: 0 0;
+}
+
+.thermal-ticket__edge--bottom {
+    bottom: -8px;
+    transform: scaleY(-1);
+}
+
+/* ===== Alfinete decorativo ===== */
+.thermal-ticket__pin {
+    position: absolute;
+    top: -8px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 32% 30%, #ff6b6b 0%, #c92a2a 60%, #8b1414 100%);
+    box-shadow:
+        0 3px 6px rgba(0, 0, 0, 0.45),
+        0 5px 10px rgba(0, 0, 0, 0.3),
+        inset 0 1px 1px rgba(255, 255, 255, 0.35);
+    z-index: 2;
+}
+
+/* ===== Header ===== */
+.thermal-ticket__header {
+    text-align: center;
+    margin-bottom: 14px;
+}
+
+.thermal-ticket__store {
+    font-size: 9px;
+    letter-spacing: 3px;
+    color: var(--thermal-ink-soft);
+    text-transform: uppercase;
+    margin: 0 0 14px;
+    font-weight: 500;
+}
+
+.thermal-ticket__title {
+    font-family: var(--app-font-brand);
+    font-size: clamp(2.1rem, 10vw, 2.85rem);
+    line-height: 0.92;
+    color: var(--thermal-ink);
+    margin: 0 0 8px;
+    letter-spacing: -1px;
+    text-transform: uppercase;
+    font-weight: 400;
+}
+
+.thermal-ticket__title span {
+    display: block;
+}
+
+.thermal-ticket__subtitle {
+    font-size: 13px;
+    color: var(--thermal-ink);
+    font-weight: 700;
+    margin: 10px 0 4px;
+    letter-spacing: 0.5px;
+    word-break: break-word;
+}
+
+.thermal-ticket__meta {
+    font-size: 9px;
+    color: var(--thermal-ink-soft);
+    margin: 0;
+    letter-spacing: 0.5px;
+}
+
+/* ===== Dividers ===== */
+.thermal-ticket__divider {
+    margin: 12px 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-align: center;
+}
+
+.thermal-ticket__divider--asterisks {
+    font-size: 12px;
+    letter-spacing: 4px;
+    color: var(--thermal-ink);
+    font-weight: 700;
+    margin: 14px 0;
+}
+
+.thermal-ticket__divider--dashed {
+    border-top: 1px dashed var(--thermal-ink-soft);
+    margin: 14px 0;
+}
+
+/* ===== Sections ===== */
+.thermal-ticket__section {
+    margin: 12px 0;
+}
+
+.thermal-ticket__section-title {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--thermal-ink);
+    margin: 0 0 8px;
+}
+
+/* ===== Rows ===== */
+.thermal-ticket__rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.thermal-ticket__row {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    margin: 5px 0;
+    font-size: 12px;
+    line-height: 1.6;
+}
+
+.thermal-ticket__row--zero {
+    opacity: 0.55;
+}
+
+.thermal-ticket__row-name {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--thermal-ink);
+    font-weight: 600;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+}
+
+.thermal-ticket__row-name-detail {
+    display: block;
+    font-size: 9px;
+    color: var(--thermal-ink-soft);
+    letter-spacing: 0.5px;
+    margin-top: 2px;
+    font-weight: 400;
+    text-transform: uppercase;
+}
+
+.thermal-ticket__row-leader {
+    flex: 1;
+    min-width: 14px;
+    height: 1em;
+    background-image: radial-gradient(circle, var(--thermal-ink-soft) 0.5px, transparent 1.2px);
+    background-size: 5px 5px;
+    background-repeat: repeat-x;
+    background-position: center 70%;
+    align-self: flex-end;
+    margin: 0 4px;
+}
+
+.thermal-ticket__row-value {
+    flex-shrink: 0;
+    white-space: nowrap;
+    color: var(--thermal-ink);
+    font-weight: 700;
+    font-feature-settings: "tnum";
+    font-variant-numeric: tabular-nums;
+}
+
+.thermal-ticket__row-value[data-sign="+"] { color: var(--thermal-ink-credit); }
+.thermal-ticket__row-value[data-sign="-"] { color: var(--thermal-ink-debit); }
+.thermal-ticket__row-value[data-sign="0"] { color: var(--thermal-ink-dim); }
+
+/* ===== Position badge ===== */
+.thermal-ticket__pos-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border: 1px solid var(--thermal-ink-soft);
+    border-radius: 2px;
+    font-size: 9px;
+    font-weight: 700;
+    color: var(--thermal-ink-soft);
+    letter-spacing: 0.5px;
+    line-height: 1.3;
+    flex-shrink: 0;
+}
+
+.thermal-ticket__pos-badge[data-pos-tier="mito"] {
+    background: var(--thermal-ink);
+    color: var(--thermal-paper);
+    border-color: var(--thermal-ink);
+}
+
+.thermal-ticket__pos-badge[data-pos-tier="mico"] {
+    background: var(--thermal-ink-debit);
+    color: var(--thermal-paper);
+    border-color: var(--thermal-ink-debit);
+}
+
+/* ===== Subtotal ===== */
+.thermal-ticket__subtotal {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-top: 10px;
+    padding-top: 6px;
+    border-top: 1px dotted var(--thermal-ink-soft);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.thermal-ticket__subtotal-label {
+    color: var(--thermal-ink-soft);
+    font-weight: 700;
+}
+
+.thermal-ticket__subtotal-value {
+    color: var(--thermal-ink);
+    font-weight: 700;
+    font-feature-settings: "tnum";
+    font-variant-numeric: tabular-nums;
+}
+
+.thermal-ticket__subtotal-value[data-sign="+"] { color: var(--thermal-ink-credit); }
+.thermal-ticket__subtotal-value[data-sign="-"] { color: var(--thermal-ink-debit); }
+
+/* ===== Display final (saldo) ===== */
+.thermal-ticket__display {
+    text-align: center;
+    padding: 18px 12px;
+    margin: 8px -8px;
+    background: var(--thermal-paper-highlight);
+    border-top: 2px solid var(--thermal-ink);
+    border-bottom: 2px solid var(--thermal-ink);
+}
+
+.thermal-ticket__display-label {
+    font-size: 10px;
+    letter-spacing: 3px;
+    color: var(--thermal-ink-soft);
+    margin: 0 0 6px;
+    text-transform: uppercase;
+    font-weight: 700;
+}
+
+.thermal-ticket__display-value {
+    font-family: var(--app-font-brand);
+    font-size: clamp(2.25rem, 9vw, 3.25rem);
+    line-height: 1;
+    color: var(--thermal-ink);
+    margin: 4px 0;
+    letter-spacing: -1px;
+    font-feature-settings: "tnum";
+    font-variant-numeric: tabular-nums;
+    word-break: break-word;
+}
+
+.thermal-ticket__display-value[data-sign="+"] { color: var(--thermal-ink-credit); }
+.thermal-ticket__display-value[data-sign="-"] { color: var(--thermal-ink-debit); }
+
+.thermal-ticket__display-status {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 4px 14px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 2.5px;
+    text-transform: uppercase;
+    border-radius: 2px;
+}
+
+.thermal-ticket__display-status[data-status="credito"]  { background: var(--thermal-ink-credit); color: var(--thermal-paper); }
+.thermal-ticket__display-status[data-status="debito"]   { background: var(--thermal-ink-debit);  color: var(--thermal-paper); }
+.thermal-ticket__display-status[data-status="quitado"]  { background: var(--thermal-ink);        color: var(--thermal-paper); }
+.thermal-ticket__display-status[data-status="aguardando"] {
+    background: transparent;
+    border: 1px solid var(--thermal-ink-soft);
+    color: var(--thermal-ink-soft);
+}
+
+/* ===== Note (pré-temporada) ===== */
+.thermal-ticket__note {
+    font-size: 11px;
+    color: var(--thermal-ink-soft);
+    text-align: center;
+    margin: 14px 0;
+    line-height: 1.55;
+    font-style: italic;
+    padding: 0 8px;
+}
+
+/* ===== Barcode ===== */
+.thermal-ticket__barcode {
+    margin: 20px auto 12px;
+    text-align: center;
+}
+
+.thermal-ticket__barcode-bars {
+    display: block;
+    width: 78%;
+    height: 52px;
+    margin: 0 auto;
+    background-image: repeating-linear-gradient(
+        to right,
+        var(--thermal-ink) 0 2px, transparent 2px 4px,
+        var(--thermal-ink) 4px 5px, transparent 5px 9px,
+        var(--thermal-ink) 9px 12px, transparent 12px 14px,
+        var(--thermal-ink) 14px 15px, transparent 15px 19px,
+        var(--thermal-ink) 19px 21px, transparent 21px 23px,
+        var(--thermal-ink) 23px 26px, transparent 26px 28px,
+        var(--thermal-ink) 28px 30px, transparent 30px 33px,
+        var(--thermal-ink) 33px 34px, transparent 34px 37px
+    );
+}
+
+.thermal-ticket__barcode-num {
+    display: block;
+    margin-top: 6px;
+    font-size: 10px;
+    letter-spacing: 4px;
+    color: var(--thermal-ink);
+    font-weight: 700;
+    word-break: break-all;
+}
+
+/* ===== Footer ===== */
+.thermal-ticket__footer {
+    text-align: center;
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px dashed var(--thermal-ink-soft);
+}
+
+.thermal-ticket__footer p {
+    margin: 4px 0;
+    font-size: 9px;
+    letter-spacing: 1px;
+    color: var(--thermal-ink-soft);
+    text-transform: uppercase;
+}
+
+.thermal-ticket__footer-thanks {
+    font-size: 11px !important;
+    font-weight: 700;
+    color: var(--thermal-ink) !important;
+    letter-spacing: 2.5px !important;
+    margin-bottom: 8px !important;
+}
+
+/* ===== Empty / Erro state genérico ===== */
+.thermal-ticket__empty {
+    text-align: center;
+    padding: 24px 12px;
+    color: var(--thermal-ink-soft);
+    font-size: 11px;
+    line-height: 1.6;
+}
+
+/* ===== Tablet ===== */
+@media (min-width: 768px) {
+    .thermal-ticket {
+        max-width: 420px;
+        padding: 36px 28px 28px;
+        font-size: 14px;
+    }
+
+    .thermal-ticket__row { font-size: 13px; }
+    .thermal-ticket__display { padding: 22px 16px; }
+}
+
+/* ===== Desktop ===== */
+@media (min-width: 1024px) {
+    .thermal-stage {
+        padding: 40px 16px 64px;
+    }
+
+    .thermal-ticket {
+        max-width: 460px;
+        margin: 32px auto;
+        transform: rotate(-0.4deg);
+        transition: transform 0.3s ease;
+    }
+
+    .thermal-ticket:hover {
+        transform: rotate(0deg);
+    }
+}

--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -102,8 +102,8 @@
         <!-- ✅ Copa do Mundo 2026 (flip cards sedes, modal estádio, home strip, countdown) -->
         <link rel="stylesheet" href="css/copa-mundo-2026.css?v=20260409" />
 
-        <!-- ✅ Extrato Bank (redesign banco digital) -->
-        <link rel="stylesheet" href="css/extrato-bank.css?v=20260322" />
+        <!-- ✅ Extrato Thermal Ticket (cupom de impressora térmica) -->
+        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260503" />
 
         <!-- ✅ Loading Overlay (navegação entre módulos) -->
         <link rel="stylesheet" href="css/pull-refresh.css?v=20260322" />

--- a/public/participante/js/modules/participante-extrato-ui.js
+++ b/public/participante/js/modules/participante-extrato-ui.js
@@ -1,29 +1,14 @@
 // =====================================================
-// MÓDULO: UI DO EXTRATO PARTICIPANTE - v11.3 HERO CARD SALDO PROJETADO
+// MÓDULO: UI DO EXTRATO PARTICIPANTE — v12.0 THERMAL TICKET
 // =====================================================
-// ✅ v11.2: FIX REFORÇADO - Múltiplas correções na classificação de zona
-//   - getFaixasParaRodada agora verifica se faixas explícitas existem antes de usar
-//   - classificarPosicao/getPosicaoZonaLabel tratam posições >= debito.inicio como débito
-//   - Posições acima do máximo configurado (ex: 34º em liga de 32) agora são débito
-//   - Validação defensiva de faixas antes de acessar propriedades
-// ✅ v11.1: FIX CRÍTICO - Ícones de zona (X/○/✓) mostravam errado
-//   - ligaConfigCache não era populado com dados do backend
-//   - Fallback de 32 participantes era usado mesmo com liga de 35+
-//   - Posições > 32 eram classificadas como "neutro" (○) ao invés de "débito" (X)
-//   - Agora usa extrato.ligaConfig.zonaConfig que já vem do backend
-// ✅ v11.0: REDESIGN COMPLETO — estilo banco digital (Nubank/Inter)
-//   - Hero Saldo Card com eye toggle + glassmorphism
-//   - Quick Stats Row (pills horizontais)
-//   - Transaction Timeline cronológico (substitui cards por rodada)
-//   - Performance Card com glass background
-//   - Skeleton shimmer loading
-//   - Zero mudanças no data contract (participante-extrato.js v4.11)
+// Estilo: ticket de impressora térmica (papel branco off-white)
+// Substitui o redesign "banco digital" (v11.x). Mantém data contract intacto.
 // =====================================================
 
-if (window.Log) Log.info("[EXTRATO-UI] v11.2 FIX ZONA ICONS ROBUSTEZ");
+if (window.Log) Log.info("[EXTRATO-UI] v12.0 THERMAL TICKET");
 
 // ===== CONSTANTES =====
-const DEFAULT_TOTAL_PARTICIPANTES = 32; // Fallback quando API não retorna total_participantes
+const DEFAULT_TOTAL_PARTICIPANTES = 32;
 
 // ===== CONFIG CACHE =====
 let ligaConfigCache = null;
@@ -84,13 +69,9 @@ function getFaixasParaRodada(ligaId, rodada) {
         totalTimes = rankingConfig.total_participantes || DEFAULT_TOTAL_PARTICIPANTES;
     }
 
-    // ✅ v11.1 FIX: Se faixas explícitas existem, usar. Senão, calcular dinamicamente.
-    // Isso garante que posições > totalTimes caiam na zona de débito corretamente.
     if (faixas?.credito && faixas?.debito) {
         return { nome: config.liga_nome, totalTimes, ...faixas };
     }
-
-    // Fallback: calcular faixas dinamicamente
     return detectarFaixasPorTotal(totalTimes);
 }
 
@@ -112,98 +93,11 @@ function detectarFaixasPorTotal(totalTimes) {
     };
 }
 
-function classificarPosicao(posicao, faixas) {
-    if (!posicao) return "neutro";
-    if (!faixas?.credito || !faixas?.debito) return "neutro";
-
-    // Zona de crédito (ganho)
-    if (posicao >= faixas.credito.inicio && posicao <= faixas.credito.fim) return "credito";
-
-    // Zona de débito (perda) - inclui posições ACIMA do máximo configurado
-    // Ex: Se debito.fim = 35, posições 36, 37, etc também são débito
-    if (posicao >= faixas.debito.inicio) return "debito";
-
-    return "neutro";
-}
-
-function getPosicaoZonaLabel(posicao, faixas) {
-    if (!posicao) return { label: null, tipo: "neutro" };
-    if (!faixas?.credito || !faixas?.debito) return { label: null, tipo: "neutro" };
-
-    // Zona de crédito (ganho)
-    if (posicao >= faixas.credito.inicio && posicao <= faixas.credito.fim) {
-        return { label: `G${posicao}`, tipo: "ganho" };
-    }
-
-    // Zona de débito (perda) - inclui posições ACIMA do máximo configurado
-    if (posicao >= faixas.debito.inicio) {
-        const zNum = Math.max(1, faixas.debito.fim - posicao + 1);
-        return { label: `Z${zNum}`, tipo: "perda" };
-    }
-
-    return { label: null, tipo: "neutro" };
-}
-
-/**
- * Retorna indicador visual de zona (Material Icon)
- * Verde = zona de ganho (crédito)
- * Cinza = zona neutra
- * Vermelho = zona de perda (débito)
- */
-function getZonaIndicator(posicao, faixas) {
-    if (!posicao || !faixas) return '<span class="material-icons extrato-tl__zona-icon extrato-tl__zona-icon--neutral">radio_button_unchecked</span>';
-    const tipo = classificarPosicao(posicao, faixas);
-    const icons = {
-        'credito': '<span class="material-icons extrato-tl__zona-icon extrato-tl__zona-icon--credito">check_circle</span>',
-        'neutro': '<span class="material-icons extrato-tl__zona-icon extrato-tl__zona-icon--neutral">radio_button_unchecked</span>',
-        'debito': '<span class="material-icons extrato-tl__zona-icon extrato-tl__zona-icon--debito">cancel</span>'
-    };
-    return icons[tipo] || icons['neutro'];
-}
-
 // ===== HELPERS =====
-function calcularPosicaoTop10(valor, ligaId) {
-    const absValor = Math.abs(valor);
-    const config = ligaConfigCache || window.ligaConfigCache;
-    const totalParticipantes = config?.total_participantes || config?.ranking_rodada?.total_participantes || DEFAULT_TOTAL_PARTICIPANTES;
-    const isLigaGrande = totalParticipantes > 20;
-    if (isLigaGrande) {
-        const pos = Math.round((30 - absValor) / 2) + 1;
-        return Math.min(Math.max(pos, 1), 10);
-    } else {
-        const pos = 11 - absValor;
-        return Math.min(Math.max(pos, 1), 10);
-    }
-}
-
 function formatarMoeda(valor) {
     return `R$ ${Math.abs(valor).toFixed(2).replace(".", ",")}`;
 }
 
-function sinalMoeda(valor) {
-    if (valor > 0) return `+${formatarMoeda(valor)}`;
-    if (valor < 0) return `-${formatarMoeda(valor)}`;
-    return formatarMoeda(0);
-}
-
-// ===== EYE TOGGLE (localStorage) =====
-function getSaldoHidden() {
-    try { return localStorage.getItem('scm_hide_saldo') === '1'; } catch { return false; }
-}
-
-function toggleSaldoVisibility() {
-    try {
-        const hidden = !getSaldoHidden();
-        localStorage.setItem('scm_hide_saldo', hidden ? '1' : '0');
-        const valorEl = document.querySelector('.extrato-hero__valor');
-        const eyeIcon = document.getElementById('eyeToggleIcon');
-        if (valorEl) valorEl.classList.toggle('extrato-hero__valor--hidden', hidden);
-        if (eyeIcon) eyeIcon.textContent = hidden ? 'visibility_off' : 'visibility';
-    } catch (e) { /* silencioso */ }
-}
-window.toggleSaldoVisibility = toggleSaldoVisibility;
-
-// ===== PREENCHER RODADAS =====
 function preencherTodasRodadas(rodadasExistentes) {
     if (!rodadasExistentes || rodadasExistentes.length === 0) return [];
     const rodadasMap = new Map();
@@ -223,743 +117,327 @@ function preencherTodasRodadas(rodadasExistentes) {
     return todasRodadas;
 }
 
-// =====================================================================
-// RENDER: HERO SALDO CARD
-// =====================================================================
-function renderHeroSaldoCard(saldo, statusTexto, taxaInscricao, pagouInscricao, temporada) {
-    const saldoHidden = getSaldoHidden();
-    const isPositivo = saldo > 0;
-    const isNegativo = saldo < 0;
-    const isZero = saldo === 0;
+// Defensivo — fallback caso window.escapeHtml não esteja disponível
+function safeEscapeHtml(str) {
+    if (typeof window.escapeHtml === 'function') return window.escapeHtml(str);
+    if (str == null) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
 
-    const heroVariant = isPositivo ? 'extrato-hero--positive' : isNegativo ? 'extrato-hero--negative' : 'extrato-hero--zero';
-    const valorClass = isPositivo ? 'extrato-hero__valor--positive' : isNegativo ? 'extrato-hero__valor--negative' : 'extrato-hero__valor--zero';
-    const statusClass = isNegativo ? 'extrato-hero__status--devedor' : isPositivo ? 'extrato-hero__status--credor' : 'extrato-hero__status--quitado';
+// =====================================================================
+// THERMAL TICKET — RENDER HELPERS
+// =====================================================================
+
+function getNomeLancamento(l, temporada) {
+    if (l.tipo === 'INSCRICAO_TEMPORADA') return `INSCRIÇÃO ${temporada}`;
+    if (l.tipo === 'TRANSFERENCIA_SALDO' || l.tipo === 'SALDO_TEMPORADA_ANTERIOR') return 'SALDO ANTERIOR';
+    return safeEscapeHtml((l.descricao || l.tipo || 'LANÇAMENTO')).toUpperCase();
+}
+
+function valorTextWithSign(valor) {
+    if (valor === 0) return formatarMoeda(0);
+    return `${valor > 0 ? '+ ' : '− '}${formatarMoeda(valor)}`;
+}
+
+function signKey(valor) {
+    if (valor > 0) return '+';
+    if (valor < 0) return '-';
+    return '0';
+}
+
+function renderRow({ name, detail = '', valor = 0, isZero = false, allowHtmlInName = false }) {
+    const sign = signKey(valor);
+    const valueText = isZero ? '—' : valorTextWithSign(valor);
+    const nameHtml = allowHtmlInName ? name : safeEscapeHtml(name);
+    const detailHtml = detail
+        ? `<span class="thermal-ticket__row-name-detail">${safeEscapeHtml(detail)}</span>`
+        : '';
+    const rowClass = (valor === 0 || isZero)
+        ? 'thermal-ticket__row thermal-ticket__row--zero'
+        : 'thermal-ticket__row';
 
     return `
-        <div class="extrato-hero ${heroVariant}">
-            <div class="extrato-hero__header">
-                <span class="extrato-hero__label">Saldo Financeiro</span>
-                <div class="extrato-hero__actions">
-                    <button class="extrato-hero__btn" onclick="window.toggleSaldoVisibility()" aria-label="Mostrar/ocultar saldo">
-                        <span class="material-icons" id="eyeToggleIcon">${saldoHidden ? 'visibility_off' : 'visibility'}</span>
-                    </button>
-                    <button class="extrato-hero__btn" id="btnRefreshExtrato" aria-label="Atualizar extrato">
-                        <span class="material-icons">sync</span>
-                    </button>
-                </div>
-            </div>
-            <div class="extrato-hero__valor ${valorClass} ${saldoHidden ? 'extrato-hero__valor--hidden' : ''}">
-                ${isNegativo ? '-' : isPositivo ? '+' : ''}${formatarMoeda(saldo)}
-            </div>
-            <div class="extrato-hero__status ${statusClass}">
-                <span class="material-icons" style="font-size: 14px;">${isNegativo ? 'trending_down' : isPositivo ? 'trending_up' : 'check_circle'}</span>
-                ${statusTexto}
-            </div>
+        <li class="${rowClass}">
+            <span class="thermal-ticket__row-name">${nameHtml}${detailHtml}</span>
+            <span class="thermal-ticket__row-leader" aria-hidden="true"></span>
+            <span class="thermal-ticket__row-value" data-sign="${sign}">${valueText}</span>
+        </li>
+    `;
+}
+
+function renderSubtotal(label, valor) {
+    return `
+        <div class="thermal-ticket__subtotal">
+            <span class="thermal-ticket__subtotal-label">${safeEscapeHtml(label)}</span>
+            <span class="thermal-ticket__subtotal-value" data-sign="${signKey(valor)}">${valorTextWithSign(valor)}</span>
         </div>
     `;
 }
 
 // =====================================================================
-// RENDER: QUICK STATS ROW
+// THERMAL TICKET — MAIN RENDERER
 // =====================================================================
-function renderQuickStatsRow(resumo, rodadas, acertos) {
-    const totalRodadas = rodadas.filter(r => r.rodada > 0).length;
-    const totalPago = acertos?.resumo?.totalPago || 0;
 
-    // Melhor rodada
-    let melhorRodada = null;
-    let melhorSaldo = -Infinity;
-    rodadas.forEach(r => {
-        const s = (r.bonusOnus || 0) + (r.pontosCorridos || 0) + (r.mataMata || 0) + (r.top10 || 0) + (r.restaUm || 0);
-        if (s > melhorSaldo) { melhorSaldo = s; melhorRodada = r.rodada; }
+function renderThermalTicket(extrato, acertos, ligaId, options = {}) {
+    const { isPreTemporadaMode = false } = options;
+
+    // ===== Identidade do time/liga =====
+    const timeNome = safeEscapeHtml(
+        extrato.time?.nome
+        || extrato.timeNome
+        || window.participanteData?.time?.nome
+        || window.participanteData?.timeNome
+        || 'Meu Time'
+    );
+
+    const temporada = window.seasonSelector?.getTemporadaSelecionada?.()
+        || window.ParticipanteConfig?.CURRENT_SEASON
+        || 2026;
+
+    const ligaNomeRaw = extrato.ligaConfig?.nome
+        || extrato.ligaConfig?.liga_nome
+        || extrato.ligaNome
+        || (ligaId ? `Liga #${ligaId}` : 'Liga');
+
+    const dataEmissao = new Date().toLocaleString('pt-BR', {
+        day: '2-digit', month: '2-digit', year: 'numeric',
+        hour: '2-digit', minute: '2-digit'
     });
 
-    const saldo = resumo.saldo_atual ?? resumo.saldo ?? 0;
-    const saldoColor = saldo >= 0 ? 'color: var(--app-success-light)' : 'color: var(--app-danger-light)';
+    const saldoFinal = extrato.saldo
+        ?? extrato.resumo?.saldo_atual
+        ?? extrato.resumo?.saldo
+        ?? 0;
 
-    return `
-        <div class="extrato-stats">
-            <div class="extrato-stat-pill">
-                <span class="material-icons extrato-stat-pill__icon">bar_chart</span>
-                <div class="extrato-stat-pill__content">
-                    <span class="extrato-stat-pill__label">Rodadas</span>
-                    <span class="extrato-stat-pill__value">${totalRodadas}</span>
-                </div>
-            </div>
-            <div class="extrato-stat-pill">
-                <span class="material-icons extrato-stat-pill__icon">account_balance_wallet</span>
-                <div class="extrato-stat-pill__content">
-                    <span class="extrato-stat-pill__label">Saldo</span>
-                    <span class="extrato-stat-pill__value" style="${saldoColor}">${sinalMoeda(saldo)}</span>
-                </div>
-            </div>
-            <div class="extrato-stat-pill">
-                <span class="material-icons extrato-stat-pill__icon">payments</span>
-                <div class="extrato-stat-pill__content">
-                    <span class="extrato-stat-pill__label">Pago</span>
-                    <span class="extrato-stat-pill__value">${formatarMoeda(totalPago)}</span>
-                </div>
-            </div>
-            ${melhorRodada ? `
-            <div class="extrato-stat-pill">
-                <span class="material-icons extrato-stat-pill__icon">star</span>
-                <div class="extrato-stat-pill__content">
-                    <span class="extrato-stat-pill__label">Melhor</span>
-                    <span class="extrato-stat-pill__value" style="color: ${melhorSaldo >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">R${melhorRodada} ${melhorSaldo >= 0 ? '+' : ''}${melhorSaldo.toFixed(0)}</span>
-                </div>
-            </div>` : ''}
-        </div>
-    `;
-}
+    // ===== Build sections =====
+    const lancamentos = extrato.lancamentosIniciais || [];
+    const entradas = lancamentos.filter(l => l.tipo !== 'AJUSTE' && l.tipo !== 'AJUSTE_MANUAL');
+    const ajustes = lancamentos.filter(l => l.tipo === 'AJUSTE' || l.tipo === 'AJUSTE_MANUAL');
 
-// =====================================================================
-// RENDER: EVOLUTION CHART
-// =====================================================================
-function renderEvolutionChart(isPreTemporadaMode) {
-    const filterButtons = isPreTemporadaMode
-        ? `<span class="extrato-chart__filter-btn extrato-chart__filter-btn--active" style="cursor:default">PRÉ-TEMPORADA</span>`
-        : `
-            <button class="filtro-btn extrato-chart__filter-btn extrato-chart__filter-btn--active" data-range="all">Tudo</button>
-            <button class="filtro-btn extrato-chart__filter-btn" data-range="10">10R</button>
-            <button class="filtro-btn extrato-chart__filter-btn" data-range="5">5R</button>
-        `;
-
-    return `
-        <div class="extrato-chart">
-            <div class="extrato-chart__header">
-                <span class="extrato-chart__title">Evolução Financeira</span>
-                <div class="extrato-chart__filters">${filterButtons}</div>
-            </div>
-            <div class="extrato-chart__svg-container">
-                <svg id="graficoSVG" style="position:absolute;inset:0;width:100%;height:100%" viewBox="0 0 300 160" preserveAspectRatio="none" fill="none">
-                    <defs>
-                        <linearGradient id="chartGradientPositive" x1="0" x2="0" y1="0" y2="1">
-                            <stop offset="0%" stop-color="var(--app-success)" stop-opacity="0.25"></stop>
-                            <stop offset="100%" stop-color="var(--app-success)" stop-opacity="0"></stop>
-                        </linearGradient>
-                        <linearGradient id="chartGradientNegative" x1="0" x2="0" y1="0" y2="1">
-                            <stop offset="0%" stop-color="var(--app-danger)" stop-opacity="0.25"></stop>
-                            <stop offset="100%" stop-color="var(--app-danger)" stop-opacity="0"></stop>
-                        </linearGradient>
-                        <linearGradient id="chartGradient" x1="0" x2="0" y1="0" y2="1">
-                            <stop offset="0%" stop-color="var(--app-primary)" stop-opacity="0.3"></stop>
-                            <stop offset="100%" stop-color="var(--app-primary)" stop-opacity="0"></stop>
-                        </linearGradient>
-                    </defs>
-                    <line class="extrato-chart__zero-line" x1="0" x2="300" y1="80" y2="80"></line>
-                    <path id="graficoArea" fill="url(#chartGradient)" d=""></path>
-                    <path id="graficoPath" fill="none" stroke="var(--app-primary)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" d=""></path>
-                </svg>
-                <div id="graficoLabels" style="position:absolute;inset:0;top:auto;display:flex;justify-content:space-between;font-size:10px;color:var(--app-text-dim);padding:0 4px"></div>
-            </div>
-        </div>
-    `;
-}
-
-// =====================================================================
-// RENDER: TRANSACTION TIMELINE
-// =====================================================================
-function renderTransactionTimeline(rodadas, acertos, lancamentosIniciais, ligaId) {
-    const items = [];
-
-    // 1. Lançamentos iniciais (inscrição, saldo anterior) + Ajustes financeiros (Resta Um, multas)
-    if (lancamentosIniciais && lancamentosIniciais.length > 0) {
-        // Separar inscrição/legado dos ajustes financeiros
-        const entradas = lancamentosIniciais.filter(l => l.tipo !== 'AJUSTE' && l.tipo !== 'AJUSTE_MANUAL');
-        const ajustes = lancamentosIniciais.filter(l => l.tipo === 'AJUSTE' || l.tipo === 'AJUSTE_MANUAL');
-
-        const renderLancamentoItem = (l) => {
-            const isDebit = l.valor < 0;
-            const isAjuste = l.tipo === 'AJUSTE' || l.tipo === 'AJUSTE_MANUAL';
-            const iconType = l.tipo === 'INSCRICAO_TEMPORADA' ? 'inscricao' : (isAjuste ? (isDebit ? 'debit' : 'credit') : (isDebit ? 'debit' : 'credit'));
-            const iconName = l.tipo === 'INSCRICAO_TEMPORADA' ? 'receipt_long' : (isAjuste ? 'gavel' : (isDebit ? 'trending_down' : 'savings'));
-            return `
-                <div class="extrato-timeline__item">
-                    <div class="extrato-timeline__item-icon extrato-timeline__item-icon--${iconType}">
-                        <span class="material-icons">${iconName}</span>
-                    </div>
-                    <div class="extrato-timeline__item-content">
-                        <div class="extrato-timeline__item-title">${escapeHtml(l.descricao || l.tipo)}</div>
-                    </div>
-                    <div class="extrato-timeline__item-value" style="color: ${isDebit ? 'var(--app-danger-light)' : 'var(--app-success-light)'}">
-                        ${isDebit ? '-' : '+'}${formatarMoeda(l.valor)}
-                    </div>
-                </div>
-            `;
-        };
-
-        // 1a. Grupo de inscrição/legado
-        if (entradas.length > 0) {
-            const groupItems = entradas.map(renderLancamentoItem);
-            const totalInicial = entradas.reduce((s, l) => s + (l.valor || 0), 0);
-            items.push({
-                order: 0,
-                html: `
-                    <div class="extrato-timeline__group">
-                        <div class="extrato-timeline__group-header">
-                            <span class="extrato-timeline__group-label">Inscrição</span>
-                            <span class="extrato-timeline__group-total" style="color: ${totalInicial >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">
-                                ${sinalMoeda(totalInicial)}
-                            </span>
-                        </div>
-                        <div class="extrato-timeline__group-items">${groupItems.join('')}</div>
-                    </div>`
-            });
-        }
-
-        // 1b. Grupo de ajustes financeiros (Resta Um, multas, etc.)
-        if (ajustes.length > 0) {
-            const ajusteItems = ajustes.map(renderLancamentoItem);
-            const totalAjustes = ajustes.reduce((s, l) => s + (l.valor || 0), 0);
-            items.push({
-                order: 0.5, // Entre inscrição (0) e rodadas (1+)
-                html: `
-                    <div class="extrato-timeline__group">
-                        <div class="extrato-timeline__group-header">
-                            <span class="extrato-timeline__group-label">Ajustes</span>
-                            <span class="extrato-timeline__group-total" style="color: ${totalAjustes >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">
-                                ${sinalMoeda(totalAjustes)}
-                            </span>
-                        </div>
-                        <div class="extrato-timeline__group-items">${ajusteItems.join('')}</div>
-                    </div>`
-            });
-        }
-
-        const totalInicial = lancamentosIniciais.reduce((s, l) => s + (l.valor || 0), 0);
-    }
-
-    // 2. Rodadas - NOVO DESIGN: Timeline Vertical (estilo banco digital)
-    const rodadasCompletas = preencherTodasRodadas(rodadas);
+    const rodadasCompletas = isPreTemporadaMode ? [] : preencherTodasRodadas(extrato.rodadas || []);
     const rodadasOrdenadas = [...rodadasCompletas].sort((a, b) => a.rodada - b.rodada);
 
-    let saldoAcumulado = lancamentosIniciais ? lancamentosIniciais.reduce((s, l) => s + (l.valor || 0), 0) : 0;
-
-    rodadasOrdenadas.forEach(r => {
-        const bonusOnus = r.bonusOnus || 0;
-        const pontosCorridos = r.pontosCorridos || 0;
-        const mataMata = r.mataMata || 0;
-        const top10 = r.top10 || 0;
-        const restaUm = r.restaUm || 0;
-        const saldoRodada = bonusOnus + pontosCorridos + mataMata + top10 + restaUm;
-        saldoAcumulado += saldoRodada;
-
-        const faixas = getFaixasParaRodada(ligaId, r.rodada);
-        const { label: zonaLabel } = getPosicaoZonaLabel(r.posicao, faixas);
-        const zonaIndicator = getZonaIndicator(r.posicao, faixas);
-        const isMito = r.posicao === 1;
-        const isMico = r.posicao === (faixas.debito?.fim || faixas.totalTimes);
-
-        // Detalhes (Material Icons com cores dos módulos)
-        const detalhes = [];
-
-        if (bonusOnus !== 0) {
-            let bancoLabel = bonusOnus > 0 ? 'Bônus posição' : 'Ônus posição';
-            if (isMito) bancoLabel = 'MITO da Rodada';
-            else if (isMico) bancoLabel = 'MICO da Rodada';
-            else if (zonaLabel) bancoLabel = `${bonusOnus > 0 ? 'Bônus' : 'Ônus'} (${zonaLabel})`;
-            // Material Icon + cor baseada em MITO/MICO/normal
-            const iconName = isMito ? 'star' : isMico ? 'sentiment_very_dissatisfied' : 'casino';
-            const iconColor = isMito ? 'var(--app-warning)' : isMico ? 'var(--app-danger)' : 'var(--app-primary)';
-            detalhes.push({ icon: iconName, iconColor, label: bancoLabel, valor: bonusOnus });
-        }
-        if (pontosCorridos !== 0) {
-            detalhes.push({ icon: 'sports_soccer', iconColor: 'var(--app-indigo, #6366f1)', label: 'Pontos Corridos', valor: pontosCorridos });
-        }
-        if (mataMata !== 0) {
-            detalhes.push({ icon: 'emoji_events', iconColor: 'var(--app-danger)', label: 'Mata-Mata', valor: mataMata });
-        }
-        if (top10 !== 0) {
-            const posTop10 = calcularPosicaoTop10(top10, ligaId);
-            const labelTop10 = top10 > 0 ? `${posTop10}º Melhor Mito` : `${posTop10}º Pior Mico`;
-            const iconName = top10 > 0 ? 'military_tech' : 'thumb_down';
-            const iconColor = top10 > 0 ? 'var(--app-warning)' : 'var(--app-danger)';
-            detalhes.push({ icon: iconName, iconColor, label: labelTop10, valor: top10 });
-        }
-        if (restaUm !== 0) {
-            const restaUmLabel = r.restaUmDescricao || 'Resta Um - Eliminado';
-            detalhes.push({ icon: 'person_remove', iconColor: 'var(--app-danger)', label: restaUmLabel, valor: restaUm });
-        }
-        // Contar módulos extras (exclui bônus/ônus de posição base)
-        const modulosExtras = detalhes.filter(d => !['casino', 'star', 'sentiment_very_dissatisfied'].includes(d.icon)).length;
-
-        const saldoRodadaZero = saldoRodada === 0 && detalhes.length === 0;
-
-        // Cor do saldo da rodada
-        const saldoRodadaColor = saldoRodada > 0 ? 'var(--app-success-light)' : saldoRodada < 0 ? 'var(--app-danger-light)' : 'var(--app-text-dim)';
-        const saldoRodadaFormatado = saldoRodada === 0 ? '—' : sinalMoeda(saldoRodada);
-
-        // Gerar HTML dos detalhes (oculto por padrão, expande ao clicar)
-        const detalhesHtml = detalhes.length > 0 ? `
-            <div class="extrato-tl__details">
-                ${detalhes.map((d, idx) => {
-                    const isLast = idx === detalhes.length - 1;
-                    const valorColor = d.valor >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)';
-                    const valorFormatado = d.valor > 0 ? `+${d.valor.toFixed(2).replace('.', ',')}` : d.valor.toFixed(2).replace('.', ',');
-                    return `
-                        <div class="extrato-tl__detail-row">
-                            <span class="extrato-tl__detail-tree">${isLast ? '└─' : '├─'}</span>
-                            <span class="extrato-tl__detail-bullet">•</span>
-                            <span class="material-icons extrato-tl__detail-icon" style="color: ${d.iconColor}">${d.icon}</span>
-                            <span class="extrato-tl__detail-label">${d.label}</span>
-                            <span class="extrato-tl__detail-value" style="color: ${valorColor}">${valorFormatado}</span>
-                        </div>
-                    `;
-                }).join('')}
-            </div>
-        ` : '';
-
-        // DESIGN COMPACTO: Uma linha por rodada, expande ao clicar
-        items.push({
-            order: r.rodada,
-            html: `
-                <div class="extrato-tl__row ${saldoRodadaZero ? 'extrato-tl__row--empty' : ''}" data-rodada="${r.rodada}" data-saldo="${saldoRodada}" onclick="window.toggleExtratoRow(this)">
-                    <span class="extrato-tl__row-rodada">R${r.rodada}</span>
-                    <span class="extrato-tl__row-pos">${r.posicao ? r.posicao + 'º' : '—'}</span>
-                    <span class="extrato-tl__row-zona">${zonaIndicator}</span>
-                    <span class="extrato-tl__row-valor" style="color: ${saldoRodadaColor}">${saldoRodadaFormatado}</span>
-                    <span class="extrato-tl__row-saldo" style="color: ${saldoAcumulado >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">${sinalMoeda(saldoAcumulado)}</span>
-                    <span class="material-icons extrato-tl__row-expand">expand_more</span>
-                </div>
-                <div class="extrato-tl__row-details">
-                    ${detalhesHtml || '<span class="extrato-tl__empty-text">Sem movimentação</span>'}
-                    ${modulosExtras > 0 ? `<span class="extrato-tl__modules-badge">${modulosExtras} módulo${modulosExtras > 1 ? 's' : ''}</span>` : ''}
-                </div>
-            `
-        });
-    });
-
-    // 3. Acertos financeiros
     const listaAcertos = acertos?.lista || [];
+
+    const sections = [];
+
+    // --- Inscrição ---
+    if (entradas.length > 0) {
+        const total = entradas.reduce((s, l) => s + (l.valor || 0), 0);
+        const rowsHtml = entradas.map(l => renderRow({
+            name: getNomeLancamento(l, temporada),
+            valor: l.valor || 0,
+            allowHtmlInName: true
+        })).join('');
+
+        sections.push(`
+            <section class="thermal-ticket__section" data-section="inscricao">
+                <h2 class="thermal-ticket__section-title">Inscrição</h2>
+                <ul class="thermal-ticket__rows" role="list">${rowsHtml}</ul>
+                ${renderSubtotal('Subtotal', total)}
+            </section>
+        `);
+    }
+
+    // --- Rodadas ---
+    if (rodadasOrdenadas.length > 0) {
+        let totalRodadas = 0;
+        const rowsHtml = rodadasOrdenadas.map(r => {
+            const saldoR = (r.bonusOnus || 0) + (r.pontosCorridos || 0)
+                + (r.mataMata || 0) + (r.top10 || 0) + (r.restaUm || 0);
+            totalRodadas += saldoR;
+
+            const faixas = getFaixasParaRodada(ligaId, r.rodada);
+            const isMito = r.posicao === 1;
+            const debitoFim = faixas?.debito?.fim || faixas?.totalTimes;
+            const isMico = r.posicao && debitoFim && r.posicao === debitoFim;
+            const tier = isMito ? 'mito' : isMico ? 'mico' : 'normal';
+
+            const numStr = String(r.rodada).padStart(2, '0');
+            const posBadge = r.posicao
+                ? `<span class="thermal-ticket__pos-badge" data-pos-tier="${tier}">${r.posicao}º</span>`
+                : '';
+
+            const nameHtml = `RODADA ${numStr}${posBadge}`;
+            return renderRow({
+                name: nameHtml,
+                valor: saldoR,
+                isZero: saldoR === 0,
+                allowHtmlInName: true
+            });
+        }).join('');
+
+        sections.push(`
+            <section class="thermal-ticket__section" data-section="rodadas">
+                <h2 class="thermal-ticket__section-title">Rodadas — Temporada ${temporada}</h2>
+                <ul class="thermal-ticket__rows" role="list">${rowsHtml}</ul>
+                ${renderSubtotal('Subtotal Rodadas', totalRodadas)}
+            </section>
+        `);
+    }
+
+    // --- Ajustes ---
+    if (ajustes.length > 0) {
+        const total = ajustes.reduce((s, l) => s + (l.valor || 0), 0);
+        const rowsHtml = ajustes.map(l => renderRow({
+            name: (l.descricao || 'Ajuste').toUpperCase(),
+            valor: l.valor || 0
+        })).join('');
+
+        sections.push(`
+            <section class="thermal-ticket__section" data-section="ajustes">
+                <h2 class="thermal-ticket__section-title">Ajustes</h2>
+                <ul class="thermal-ticket__rows" role="list">${rowsHtml}</ul>
+                ${renderSubtotal('Subtotal', total)}
+            </section>
+        `);
+    }
+
+    // --- Acertos ---
     if (listaAcertos.length > 0) {
-        const acertosOrdenados = [...listaAcertos].sort((a, b) => new Date(b.dataAcerto || b.data || 0) - new Date(a.dataAcerto || a.data || 0));
+        const acertosOrdenados = [...listaAcertos].sort((a, b) =>
+            new Date(b.dataAcerto || b.data || 0) - new Date(a.dataAcerto || a.data || 0));
 
-        const acertoItems = acertosOrdenados.map(acerto => {
-            const isPagamento = acerto.tipo === "pagamento";
-            const valor = Math.abs(acerto.valor || 0);
-            const dataFormatada = (acerto.dataAcerto || acerto.data)
-                ? new Date(acerto.dataAcerto || acerto.data).toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" })
-                : "";
-            const metodos = { pix: 'PIX', transferencia: 'TED', dinheiro: 'Dinheiro', outro: 'Outro' };
-            const metodoLabel = metodos[acerto.metodoPagamento] || '';
-            const subtitleParts = [metodoLabel, dataFormatada].filter(Boolean).join(' · ');
+        let total = 0;
+        const rowsHtml = acertosOrdenados.map(a => {
+            const isPagamento = a.tipo === 'pagamento';
+            const valorAbs = Math.abs(a.valor || 0);
+            const valorSinal = isPagamento ? valorAbs : -valorAbs;
+            total += valorSinal;
 
-            return `
-                <div class="extrato-timeline__item">
-                    <div class="extrato-timeline__item-icon extrato-timeline__item-icon--acerto">
-                        <span class="material-icons">${isPagamento ? 'arrow_upward' : 'arrow_downward'}</span>
-                    </div>
-                    <div class="extrato-timeline__item-content">
-                        <div class="extrato-timeline__item-title">${escapeHtml(acerto.descricao || (isPagamento ? 'Pagamento' : 'Recebimento'))}</div>
-                        ${subtitleParts ? `<div class="extrato-timeline__item-subtitle">${subtitleParts}</div>` : ''}
-                    </div>
-                    <div class="extrato-timeline__item-value" style="color: ${isPagamento ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">
-                        ${isPagamento ? '+' : '-'}${formatarMoeda(valor)}
-                    </div>
-                </div>
-            `;
-        });
+            const metodos = { pix: 'PIX', transferencia: 'TED', dinheiro: 'DINHEIRO', outro: 'OUTRO' };
+            const metodo = metodos[a.metodoPagamento] || '';
+            const data = (a.dataAcerto || a.data)
+                ? new Date(a.dataAcerto || a.data).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
+                : '';
+            const detailParts = [metodo, data].filter(Boolean);
+            const detail = detailParts.join(' · ');
+            const baseLabel = isPagamento ? 'PAGAMENTO' : 'RECEBIMENTO';
+            const desc = (a.descricao || baseLabel).toUpperCase();
 
-        const totalAcertos = acertos?.resumo?.saldo || 0;
-        items.push({
-            order: 9999,
-            html: `
-                <div class="extrato-timeline__group">
-                    <div class="extrato-timeline__group-header">
-                        <span class="extrato-timeline__group-label">Acertos</span>
-                        <span class="extrato-timeline__group-total" style="color: ${totalAcertos >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">
-                            ${sinalMoeda(totalAcertos)}
-                        </span>
-                    </div>
-                    ${acertoItems.join('')}
-                </div>
-            `
-        });
+            return renderRow({ name: desc, detail, valor: valorSinal });
+        }).join('');
+
+        sections.push(`
+            <section class="thermal-ticket__section" data-section="acertos">
+                <h2 class="thermal-ticket__section-title">Acertos</h2>
+                <ul class="thermal-ticket__rows" role="list">${rowsHtml}</ul>
+                ${renderSubtotal('Subtotal Acertos', total)}
+            </section>
+        `);
     }
 
-    // Sort chronologically
-    items.sort((a, b) => a.order - b.order);
+    const sectionsWithDividers = sections.length > 0
+        ? sections.join('<div class="thermal-ticket__divider thermal-ticket__divider--dashed" aria-hidden="true"></div>')
+        : '';
 
-    // Timeline filters
-    const filterHtml = `
-        <div class="extrato-timeline__filters">
-            <button class="extrato-timeline__filter-btn extrato-timeline__filter-btn--active" data-tl-filter="all">Todos</button>
-            <button class="extrato-timeline__filter-btn" data-tl-filter="credito">Créditos</button>
-            <button class="extrato-timeline__filter-btn" data-tl-filter="debito">Débitos</button>
-            <button class="extrato-timeline__filter-btn" data-tl-filter="acertos">Acertos</button>
-        </div>
-    `;
+    const emptyNote = (sections.length === 0)
+        ? `<p class="thermal-ticket__note">// Sem movimentações registradas até o momento.</p>`
+        : (isPreTemporadaMode && rodadasOrdenadas.length === 0)
+            ? `<p class="thermal-ticket__note">// Movimentações por rodada aparecerão a partir da rodada 1.</p>`
+            : '';
 
-    return `
-        <div class="extrato-timeline">
-            ${filterHtml}
-            <div id="timelineContent">
-                ${items.length > 0 ? items.map(i => i.html).join('') : `
-                    <div class="extrato-empty">
-                        <span class="material-icons extrato-empty__icon">inbox</span>
-                        <p class="extrato-empty__title">Sem movimentações</p>
-                        <p class="extrato-empty__text">O extrato será gerado após a primeira rodada</p>
-                    </div>
-                `}
-            </div>
-        </div>
-    `;
-}
+    // ===== Display final =====
+    const isCredito = saldoFinal > 0;
+    const isDebito = saldoFinal < 0;
+    let displayLabel, displayValueText, displayValueSign, displayStatusText, displayStatusKey;
 
-// Expand/collapse timeline groups (legacy)
-window.toggleTimelineGroup = function(el) {
-    const subitems = el.parentElement.querySelector('.extrato-timeline__subitems');
-    const icon = el.querySelector('.extrato-timeline__expand-icon');
-    if (subitems) {
-        subitems.classList.toggle('extrato-timeline__subitems--open');
-    }
-    if (icon) {
-        icon.classList.toggle('extrato-timeline__expand-icon--open');
-    }
-};
-
-// Expand/collapse compacto - apenas UMA rodada expandida por vez
-window.toggleExtratoRow = function(rowEl) {
-    const isExpanded = rowEl.classList.contains('extrato-tl__row--expanded');
-    const container = rowEl.closest('.extrato-timeline') || rowEl.closest('#timelineContent');
-
-    // Colapsar TODAS as outras linhas primeiro
-    if (container) {
-        container.querySelectorAll('.extrato-tl__row--expanded').forEach(row => {
-            row.classList.remove('extrato-tl__row--expanded');
-            const details = row.nextElementSibling;
-            if (details && details.classList.contains('extrato-tl__row-details')) {
-                details.classList.remove('extrato-tl__row-details--open');
-            }
-            const icon = row.querySelector('.extrato-tl__row-expand');
-            if (icon) icon.style.transform = '';
-        });
-    }
-
-    // Se não estava expandida, expandir esta
-    if (!isExpanded) {
-        rowEl.classList.add('extrato-tl__row--expanded');
-        const details = rowEl.nextElementSibling;
-        if (details && details.classList.contains('extrato-tl__row-details')) {
-            details.classList.add('extrato-tl__row-details--open');
-        }
-        const icon = rowEl.querySelector('.extrato-tl__row-expand');
-        if (icon) icon.style.transform = 'rotate(180deg)';
-    }
-};
-
-// =====================================================================
-// RENDER: PERFORMANCE CARD
-// =====================================================================
-function renderPerformanceCard(rodadas, ligaId) {
-    if (!rodadas || rodadas.length === 0) return '';
-
-    let totalMito = 0, totalMico = 0;
-    let zonaCredito = 0, zonaDebito = 0;
-    let melhorRodada = { rodada: 0, saldo: -Infinity };
-    let piorRodada = { rodada: 0, saldo: Infinity };
-
-    rodadas.forEach(r => {
-        const faixas = getFaixasParaRodada(ligaId, r.rodada);
-        const saldo = (r.bonusOnus || 0) + (r.pontosCorridos || 0) + (r.mataMata || 0) + (r.top10 || 0) + (r.restaUm || 0);
-        if (r.top10 > 0) totalMito++;
-        if (r.top10 < 0) totalMico++;
-        if (r.posicao && r.posicao <= faixas.credito.fim) zonaCredito++;
-        if (r.posicao && r.posicao >= faixas.debito.inicio) zonaDebito++;
-        if (saldo > melhorRodada.saldo) melhorRodada = { rodada: r.rodada, saldo };
-        if (saldo < piorRodada.saldo) piorRodada = { rodada: r.rodada, saldo };
-    });
-
-    // Cor baseada no VALOR real (nao no fato de ser "melhor" ou "pior")
-    const melhorRodadaCor = melhorRodada.saldo >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)';
-    const piorRodadaCor = piorRodada.saldo >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)';
-
-    return `
-        <div class="extrato-performance">
-            <div class="extrato-performance__title">Meu Desempenho</div>
-            <div class="extrato-performance__grid">
-                <div class="extrato-performance__stat">
-                    <div class="extrato-performance__stat-value" style="color: var(--app-warning)">${totalMito}</div>
-                    <div class="extrato-performance__stat-label">Mitos</div>
-                </div>
-                <div class="extrato-performance__stat">
-                    <div class="extrato-performance__stat-value" style="color: var(--app-danger-light)">${totalMico}</div>
-                    <div class="extrato-performance__stat-label">Micos</div>
-                </div>
-                <div class="extrato-performance__stat">
-                    <div class="extrato-performance__stat-value" style="color: var(--app-success-light)">${zonaCredito}</div>
-                    <div class="extrato-performance__stat-label">Zona Ganho</div>
-                </div>
-                <div class="extrato-performance__stat">
-                    <div class="extrato-performance__stat-value" style="color: var(--app-danger-light)">${zonaDebito}</div>
-                    <div class="extrato-performance__stat-label">Zona Perda</div>
-                </div>
-            </div>
-            <div class="extrato-performance__best-worst">
-                <div class="extrato-performance__best-worst-item">
-                    <div class="extrato-performance__bw-label">Melhor Rodada</div>
-                    <div class="extrato-performance__bw-value" style="color: ${melhorRodadaCor}">
-                        R${melhorRodada.rodada} (${sinalMoeda(melhorRodada.saldo)})
-                    </div>
-                </div>
-                <div class="extrato-performance__best-worst-item">
-                    <div class="extrato-performance__bw-label">Pior Rodada</div>
-                    <div class="extrato-performance__bw-value" style="color: ${piorRodadaCor}">
-                        R${piorRodada.rodada} (${sinalMoeda(piorRodada.saldo)})
-                    </div>
-                </div>
-            </div>
-        </div>
-    `;
-}
-
-// =====================================================================
-// RENDER: BOTTOM SHEET ACERTOS (mantido do v10.2)
-// =====================================================================
-function renderBottomSheetAcertos(listaAcertos, resumoAcertos, saldoTemporada, saldoAcertos) {
-    const totalPago = resumoAcertos?.totalPago || 0;
-    const totalRecebido = resumoAcertos?.totalRecebido || 0;
-    const saldoFinal = saldoTemporada + saldoAcertos;
-    const temAcertos = listaAcertos && listaAcertos.length > 0;
-
-    const acertosOrdenados = temAcertos
-        ? [...listaAcertos].sort((a, b) => new Date(b.dataAcerto || b.data || 0) - new Date(a.dataAcerto || a.data || 0))
-        : [];
-
-    const listaHTML = temAcertos
-        ? acertosOrdenados.map(acerto => {
-            const isPagamento = acerto.tipo === "pagamento";
-            const valor = Math.abs(acerto.valor || 0);
-            const dataFormatada = (acerto.dataAcerto || acerto.data)
-                ? new Date(acerto.dataAcerto || acerto.data).toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit", year: "2-digit" })
-                : "--/--/--";
-            const metodos = { pix: { icon: "qr_code_2", label: "PIX" }, transferencia: { icon: "account_balance", label: "TED" }, dinheiro: { icon: "payments", label: "Dinheiro" }, outro: { icon: "receipt", label: "Outro" } };
-            const metodo = metodos[acerto.metodoPagamento] || metodos.outro;
-            const corCard = isPagamento ? "border-color: rgba(16,185,129,0.2)" : "border-color: rgba(239,68,68,0.2)";
-            const corIconBg = isPagamento ? "background: rgba(16,185,129,0.12); color: var(--app-success-light)" : "background: rgba(239,68,68,0.12); color: var(--app-danger-light)";
-            const corValor = isPagamento ? "color: var(--app-success-light)" : "color: var(--app-danger-light)";
-
-            return `
-                <div style="background: var(--app-glass-hover); border-radius: var(--app-radius-lg); padding: 12px; border: 1px solid; ${corCard}">
-                    <div style="display:flex; align-items:center; justify-content:space-between">
-                        <div style="display:flex; align-items:center; gap:12px">
-                            <div style="width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;${corIconBg}">
-                                <span class="material-icons" style="font-size:18px">${isPagamento ? 'arrow_upward' : 'arrow_downward'}</span>
-                            </div>
-                            <div>
-                                <p style="font-size:14px;color:var(--app-text-primary);font-weight:500">${escapeHtml(acerto.descricao || (isPagamento ? 'Você pagou' : 'Você recebeu'))}</p>
-                                <div style="display:flex;align-items:center;gap:8px;font-size:10px;color:var(--app-text-dim)">
-                                    <span style="display:flex;align-items:center;gap:4px">
-                                        <span class="material-icons" style="font-size:10px">${metodo.icon}</span>
-                                        ${metodo.label}
-                                    </span>
-                                    <span>·</span>
-                                    <span>${dataFormatada}</span>
-                                </div>
-                            </div>
-                        </div>
-                        <span style="font-family:'JetBrains Mono',monospace;font-size:16px;font-weight:700;${corValor}">
-                            ${isPagamento ? '-' : '+'}R$ ${valor.toFixed(2).replace('.', ',')}
-                        </span>
-                    </div>
-                </div>
-            `;
-        }).join('')
-        : `
-            <div style="text-align:center;padding:32px 0;color:var(--app-text-dim)">
-                <span class="material-icons" style="font-size:36px;display:block;margin-bottom:8px;opacity:0.4">receipt_long</span>
-                <p style="font-size:14px">Nenhum acerto registrado</p>
-                <p style="font-size:12px;color:var(--app-text-dim);margin-top:4px">Acertos e pagamentos aparecerão aqui</p>
-            </div>
-        `;
-
-    return `
-        <div id="bottomSheetAcertos" class="fixed inset-0 z-[60] hidden">
-            <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="window.fecharBottomSheetAcertos()"></div>
-            <div class="absolute bottom-0 left-0 right-0 rounded-t-3xl max-h-[85vh] flex flex-col transform translate-y-full transition-transform duration-300 ease-out" style="background: var(--app-bg-elevated, var(--app-surface))" id="bottomSheetContent">
-                <div style="display:flex;justify-content:center;padding:12px 0 8px"><div style="width:40px;height:4px;border-radius:9999px;background:var(--app-glass-hover)"></div></div>
-                <div style="padding:0 20px 16px;border-bottom:1px solid var(--app-glass-border)">
-                    <div style="display:flex;justify-content:space-between;align-items:center">
-                        <h3 style="font-size:18px;font-weight:700;color:var(--app-text-primary);display:flex;align-items:center;gap:8px">
-                            <span class="material-icons" style="color:var(--app-warning)">receipt_long</span>
-                            Meus Acertos
-                        </h3>
-                        <div style="display:flex;gap:4px">
-                            <button id="btnRefreshAcertos" onclick="window.refreshAcertosBottomSheet()" style="padding:8px;border-radius:50%;background:none;border:none;cursor:pointer;color:var(--app-text-dim)">
-                                <span class="material-icons" style="font-size:20px">sync</span>
-                            </button>
-                            <button onclick="window.fecharBottomSheetAcertos()" style="padding:8px;border-radius:50%;background:none;border:none;cursor:pointer;color:var(--app-text-dim)">
-                                <span class="material-icons">close</span>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-                <div style="padding:16px 20px;display:grid;grid-template-columns:1fr 1fr;gap:12px">
-                    <div style="background:rgba(16,185,129,0.08);border-radius:var(--app-radius-lg);padding:12px;text-align:center;border:1px solid rgba(16,185,129,0.15)">
-                        <span class="material-icons" style="color:var(--app-success-light);font-size:20px">arrow_upward</span>
-                        <p style="font-family:'JetBrains Mono',monospace;font-size:18px;font-weight:700;color:var(--app-success-light)">R$ ${totalPago.toFixed(2).replace('.', ',')}</p>
-                        <p style="font-size:10px;color:var(--app-text-dim);text-transform:uppercase">Você pagou</p>
-                    </div>
-                    <div style="background:rgba(239,68,68,0.08);border-radius:var(--app-radius-lg);padding:12px;text-align:center;border:1px solid rgba(239,68,68,0.15)">
-                        <span class="material-icons" style="color:var(--app-danger-light);font-size:20px">arrow_downward</span>
-                        <p style="font-family:'JetBrains Mono',monospace;font-size:18px;font-weight:700;color:var(--app-danger-light)">R$ ${totalRecebido.toFixed(2).replace('.', ',')}</p>
-                        <p style="font-size:10px;color:var(--app-text-dim);text-transform:uppercase">Você recebeu</p>
-                    </div>
-                </div>
-                <div style="flex:1;overflow-y:auto;padding:0 20px 16px;display:flex;flex-direction:column;gap:8px">${listaHTML}</div>
-                <div style="padding:16px 20px;border-top:1px solid var(--app-glass-border);background:var(--app-bg-card, #141414)">
-                    <div style="border-radius:var(--app-radius-lg);padding:16px;border:1px solid ${saldoFinal >= 0 ? 'rgba(16,185,129,0.2)' : 'rgba(239,68,68,0.2)'};background:${saldoFinal >= 0 ? 'rgba(16,185,129,0.06)' : 'rgba(239,68,68,0.06)'}">
-                        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;font-size:12px;color:var(--app-text-dim)">
-                            <span>Saldo do Jogo</span>
-                            <span style="color:${saldoTemporada >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">${saldoTemporada >= 0 ? '+' : ''}R$ ${Math.abs(saldoTemporada).toFixed(2).replace('.', ',')}</span>
-                        </div>
-                        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;font-size:12px;color:var(--app-text-dim)">
-                            <span>Ajuste Acertos</span>
-                            <span style="color:${saldoAcertos >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">${saldoAcertos >= 0 ? '+' : ''}R$ ${Math.abs(saldoAcertos).toFixed(2).replace('.', ',')}</span>
-                        </div>
-                        <div style="border-top:1px solid var(--app-glass-border);padding-top:12px;display:flex;justify-content:space-between;align-items:center">
-                            <span style="display:flex;align-items:center;gap:8px;font-size:14px;font-weight:700;color:var(--app-text-primary)">
-                                <span class="material-icons" style="color:var(--app-text-muted)">account_balance_wallet</span>
-                                Saldo Final
-                            </span>
-                            <span style="font-family:'JetBrains Mono',monospace;font-size:24px;font-weight:800;color:${saldoFinal >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)'}">
-                                R$ ${Math.abs(saldoFinal).toFixed(2).replace('.', ',')}
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    `;
-}
-
-// ===== BOTTOM SHEET FUNÇÕES GLOBAIS =====
-window.abrirBottomSheetAcertos = function() {
-    const sheet = document.getElementById('bottomSheetAcertos');
-    const content = document.getElementById('bottomSheetContent');
-    if (sheet && content) {
-        sheet.classList.remove('hidden');
-        content.offsetHeight;
-        setTimeout(() => { content.style.transform = 'translateY(0)'; }, 10);
-        document.body.style.overflow = 'hidden';
-    }
-};
-
-window.fecharBottomSheetAcertos = function() {
-    const sheet = document.getElementById('bottomSheetAcertos');
-    const content = document.getElementById('bottomSheetContent');
-    if (sheet && content) {
-        content.style.transform = 'translateY(100%)';
-        setTimeout(() => { sheet.classList.add('hidden'); document.body.style.overflow = ''; }, 300);
-    }
-};
-
-// ===== BOTÃO MEUS ACERTOS (pill) =====
-function renderBotaoMeusAcertos(listaAcertos, saldoAcertos) {
-    const temAcertos = listaAcertos && listaAcertos.length > 0;
-    const qtdAcertos = listaAcertos?.length || 0;
-    let badgeBg = 'background: var(--app-glass-hover); color: var(--app-text-dim)';
-    let badgeTexto = 'Nenhum';
-    if (temAcertos) {
-        if (saldoAcertos > 0) {
-            badgeBg = 'background: rgba(16,185,129,0.15); color: var(--app-success-light)';
-            badgeTexto = `+R$ ${Math.abs(saldoAcertos).toFixed(0)}`;
-        } else if (saldoAcertos < 0) {
-            badgeBg = 'background: rgba(239,68,68,0.15); color: var(--app-danger-light)';
-            badgeTexto = `-R$ ${Math.abs(saldoAcertos).toFixed(0)}`;
+    if (isPreTemporadaMode) {
+        displayLabel = 'Aguardando início';
+        displayValueText = valorTextWithSign(saldoFinal);
+        displayValueSign = signKey(saldoFinal);
+        displayStatusText = 'PRÉ-TEMPORADA';
+        displayStatusKey = 'aguardando';
+    } else {
+        displayLabel = 'Saldo Final';
+        displayValueText = valorTextWithSign(saldoFinal);
+        displayValueSign = signKey(saldoFinal);
+        if (isCredito) {
+            displayStatusText = 'CRÉDITO';
+            displayStatusKey = 'credito';
+        } else if (isDebito) {
+            displayStatusText = 'DÉBITO';
+            displayStatusKey = 'debito';
         } else {
-            badgeBg = 'background: rgba(16,185,129,0.15); color: var(--app-success-light)';
-            badgeTexto = 'Quitado';
+            displayStatusText = 'QUITADO';
+            displayStatusKey = 'quitado';
         }
     }
 
+    // ===== Barcode (decorativo) =====
+    const timeId = window.PARTICIPANTE_IDS?.timeId || window.participanteData?.timeId || '0';
+    const barcodeNum = `SCM-${temporada}-L${ligaId || '0'}-T${timeId}`.toUpperCase();
+
     return `
-        <div style="display:flex;justify-content:center;margin:var(--app-space-4) 0">
-            <button onclick="window.abrirBottomSheetAcertos()" style="
-                display:inline-flex;align-items:center;gap:8px;
-                padding:10px 18px;border-radius:9999px;
-                border:1px solid var(--app-glass-border);
-                background:var(--app-glass-bg);
-                cursor:pointer;-webkit-tap-highlight-color:transparent;
-                transition:all 0.2s ease;
-            ">
-                <span class="material-icons" style="font-size:18px;color:var(--app-warning)">receipt_long</span>
-                <span style="font-size:11px;font-weight:600;color:var(--app-text-muted);text-transform:uppercase;letter-spacing:0.5px">Meus Acertos</span>
-                <span style="font-size:10px;font-weight:700;padding:4px 10px;border-radius:9999px;${badgeBg}">${temAcertos ? qtdAcertos : badgeTexto}</span>
-            </button>
-        </div>
+        <section class="thermal-stage">
+            <article class="thermal-ticket" role="region" aria-label="Extrato financeiro de ${timeNome}">
+                <span class="thermal-ticket__edge thermal-ticket__edge--top" aria-hidden="true"></span>
+                <span class="thermal-ticket__pin" aria-hidden="true"></span>
+
+                <header class="thermal-ticket__header">
+                    <p class="thermal-ticket__store">Super Cartola Manager</p>
+                    <h1 class="thermal-ticket__title"><span>Extrato</span><span>${temporada}</span></h1>
+                    <p class="thermal-ticket__subtitle">${timeNome}</p>
+                    <p class="thermal-ticket__meta">${safeEscapeHtml(ligaNomeRaw)} · ${dataEmissao}</p>
+                </header>
+
+                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">* * * * * * * * * * * * * *</div>
+
+                ${sectionsWithDividers}
+                ${emptyNote}
+
+                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">* * * * * * * * * * * * * *</div>
+
+                <div class="thermal-ticket__display">
+                    <p class="thermal-ticket__display-label">${displayLabel}</p>
+                    <p class="thermal-ticket__display-value" data-sign="${displayValueSign}">${displayValueText}</p>
+                    <p class="thermal-ticket__display-status" data-status="${displayStatusKey}">${displayStatusText}</p>
+                </div>
+
+                <div class="thermal-ticket__barcode" aria-hidden="true">
+                    <span class="thermal-ticket__barcode-bars"></span>
+                    <span class="thermal-ticket__barcode-num">${barcodeNum}</span>
+                </div>
+
+                <footer class="thermal-ticket__footer">
+                    <p class="thermal-ticket__footer-thanks">Obrigado por jogar</p>
+                    <p>Emitido em ${dataEmissao}</p>
+                    <p>Super Cartola Manager</p>
+                </footer>
+
+                <span class="thermal-ticket__edge thermal-ticket__edge--bottom" aria-hidden="true"></span>
+            </article>
+        </section>
     `;
 }
-// Compat: expose old name on window
-window.renderizarBotaoMeusAcertos = renderBotaoMeusAcertos;
 
 // =====================================================================
-// RENDER: MAIN CONTEUDO COMPLETO
+// ORQUESTRADORES
 // =====================================================================
+
 window.renderizarConteudoCompleto = function renderizarConteudoCompleto(container, extrato) {
-    const resumoBase = extrato.resumo || { saldo: 0, totalGanhos: 0, totalPerdas: 0 };
-    const temporadaAtual = window.ParticipanteConfig?.CURRENT_SEASON || 2026;
-    const temporadaSelecionada = window.seasonSelector?.getTemporadaSelecionada?.();
-    const isPreTemporada2026 = (temporadaSelecionada || temporadaAtual) >= 2026 && isPreTemporada(extrato.rodadas);
-
-    const camposManuais = isPreTemporada2026 ? [] : (extrato.camposManuais || extrato.camposEditaveis || []);
-
-    // Saldo calculation (same as v10.7)
     const acertos = extrato.acertos || { lista: [], resumo: {} };
-    const listaAcertos = acertos.lista || [];
-    const resumoAcertos = acertos.resumo || {};
-    const saldoAcertosCalculado = resumoAcertos?.saldo ?? resumoBase?.saldo_acertos ?? 0;
-    const saldoTemporada = resumoBase.saldo_temporada ?? resumoBase.saldo_final ?? resumoBase.saldo ?? 0;
-    const saldoAcertos = saldoAcertosCalculado;
-    const saldo = resumoBase.saldo_atual ?? (saldoTemporada + saldoAcertos);
-
-    const saldoPositivo = saldo >= 0;
-    const statusTexto = saldoPositivo ? (saldo === 0 ? "QUITADO" : "A RECEBER") : "VOCÊ DEVE";
-
-    const taxaInscricao = resumoBase.taxaInscricao || 0;
-    const pagouInscricao = resumoBase.pagouInscricao === true;
-
-    const ligaId = extrato.liga_id || extrato.ligaId || window.PARTICIPANTE_IDS?.ligaId || window.participanteData?.ligaId || '';
+    const ligaId = extrato.liga_id
+        || extrato.ligaId
+        || window.PARTICIPANTE_IDS?.ligaId
+        || window.participanteData?.ligaId
+        || '';
     window.ligaIdAtual = ligaId;
 
-    if (window.Log) Log.info("[EXTRATO-UI] 💰 Renderizando:", { saldo, saldoTemporada, saldoAcertos, rodadas: extrato.rodadas?.length });
+    if (window.Log) Log.info("[EXTRATO-UI] 🎫 Ticket térmico:", {
+        saldo: extrato.saldo,
+        rodadas: extrato.rodadas?.length,
+        acertos: acertos.lista?.length || 0
+    });
 
-    const rodadasValidas = extrato.rodadas.filter(r => r.rodada > 0);
-
-    container.innerHTML = `
-        ${renderHeroSaldoCard(saldo, statusTexto, taxaInscricao, pagouInscricao, temporadaSelecionada || temporadaAtual)}
-        ${renderQuickStatsRow(resumoBase, rodadasValidas, acertos)}
-        ${renderEvolutionChart(false)}
-        ${renderTransactionTimeline(extrato.rodadas, acertos, extrato.lancamentosIniciais, ligaId)}
-        ${renderPerformanceCard(rodadasValidas, ligaId)}
-
-        <!-- Modal TOP10 Info -->
-        <div id="modalTop10Info" class="fixed inset-0 z-50 hidden items-center justify-center bg-black/70 backdrop-blur-sm p-4" onclick="this.classList.add('hidden'); this.classList.remove('flex');">
-            <div onclick="event.stopPropagation()" style="background:var(--app-bg-elevated,#1c1c1e);border-radius:var(--app-radius-2xl);width:100%;max-width:400px;overflow:hidden;box-shadow:0 24px 48px rgba(0,0,0,0.5)">
-                <div style="padding:16px;border-bottom:1px solid var(--app-glass-border)">
-                    <div style="display:flex;justify-content:space-between;align-items:center">
-                        <h3 style="font-size:16px;font-weight:700;color:var(--app-text-primary);display:flex;align-items:center;gap:8px">
-                            <span class="material-icons" style="color:var(--app-warning)">emoji_events</span>
-                            Detalhe TOP 10
-                        </h3>
-                        <button style="color:var(--app-text-dim);background:none;border:none;cursor:pointer" onclick="document.getElementById('modalTop10Info').classList.add('hidden');document.getElementById('modalTop10Info').classList.remove('flex');">
-                            <span class="material-icons">close</span>
-                        </button>
-                    </div>
-                </div>
-                <div id="modalTop10Body" style="padding:16px"></div>
-            </div>
-        </div>
-    `;
-
-    // Setup timeline filters
-    setTimeout(() => configurarFiltrosTimeline(), 50);
+    container.innerHTML = renderThermalTicket(extrato, acertos, ligaId, { isPreTemporadaMode: false });
 };
 
-// =====================================================================
-// RENDER: PRÉ-TEMPORADA (RENOVADOS)
-// =====================================================================
 function renderizarConteudoRenovadoPreTemporada(container, extrato) {
     const resumoBase = extrato.resumo || {};
     const inscricaoInfo = statusRenovacaoParticipante || {};
@@ -967,23 +445,19 @@ function renderizarConteudoRenovadoPreTemporada(container, extrato) {
     const taxaInscricao = inscricaoInfo.taxaInscricao || resumoBase.taxaInscricao || 180;
     const pagouInscricao = inscricaoInfo.pagouInscricao === true || resumoBase.pagouInscricao === true;
     const saldoAnteriorTransferido = resumoBase.saldoAnteriorTransferido || 0;
-    const debitoTaxa = pagouInscricao ? 0 : taxaInscricao;
-    const saldoCalculado = saldoAnteriorTransferido - debitoTaxa;
-    const saldo = resumoBase.saldo_atual ?? resumoBase.saldo ?? saldoCalculado;
-    const saldoPositivo = saldo >= 0;
-    const statusTexto = saldoPositivo ? (saldo === 0 ? "QUITADO" : "A RECEBER") : "VOCÊ DEVE";
 
-    const acertos = extrato.acertos || { lista: [], resumo: {} };
-    const listaAcertos = acertos.lista || [];
-    const saldoAcertos = acertos.resumo?.saldo || 0;
+    // Construir lançamentos iniciais se ausentes
+    const lancamentosIniciais = Array.isArray(extrato.lancamentosIniciais) && extrato.lancamentosIniciais.length > 0
+        ? [...extrato.lancamentosIniciais]
+        : [];
 
-    const temporadaAtual = window.ParticipanteConfig?.CURRENT_SEASON || 2026;
-
-    // Build lancamentos iniciais from pre-temporada data
-    const lancamentosIniciais = extrato.lancamentosIniciais || [];
     if (lancamentosIniciais.length === 0) {
         if (!pagouInscricao && taxaInscricao > 0) {
-            lancamentosIniciais.push({ tipo: 'INSCRICAO_TEMPORADA', descricao: 'Taxa de inscrição', valor: -taxaInscricao });
+            lancamentosIniciais.push({
+                tipo: 'INSCRICAO_TEMPORADA',
+                descricao: 'Taxa de inscrição',
+                valor: -taxaInscricao
+            });
         }
         if (saldoAnteriorTransferido !== 0) {
             lancamentosIniciais.push({
@@ -994,43 +468,25 @@ function renderizarConteudoRenovadoPreTemporada(container, extrato) {
         }
     }
 
-    container.innerHTML = `
-        ${renderHeroSaldoCard(saldo, statusTexto, taxaInscricao, pagouInscricao, temporadaAtual)}
-        ${renderEvolutionChart(true)}
-        ${renderTransactionTimeline([], acertos, lancamentosIniciais, '')}
+    const acertos = extrato.acertos || { lista: [], resumo: {} };
+    const ligaId = extrato.liga_id
+        || extrato.ligaId
+        || window.PARTICIPANTE_IDS?.ligaId
+        || '';
 
-        <!-- Card Aguardando -->
-        <div class="extrato-performance">
-            <div class="extrato-performance__title">Meu Desempenho</div>
-            <div class="extrato-performance__grid">
-                <div class="extrato-performance__stat">
-                    <div class="extrato-performance__stat-value" style="color: var(--app-text-dim)">0</div>
-                    <div class="extrato-performance__stat-label">Mitos</div>
-                </div>
-                <div class="extrato-performance__stat">
-                    <div class="extrato-performance__stat-value" style="color: var(--app-text-dim)">0</div>
-                    <div class="extrato-performance__stat-label">Micos</div>
-                </div>
-                <div class="extrato-performance__stat">
-                    <div class="extrato-performance__stat-value" style="color: var(--app-text-dim)">0</div>
-                    <div class="extrato-performance__stat-label">Zona Ganho</div>
-                </div>
-                <div class="extrato-performance__stat">
-                    <div class="extrato-performance__stat-value" style="color: var(--app-text-dim)">0</div>
-                    <div class="extrato-performance__stat-label">Zona Perda</div>
-                </div>
-            </div>
-            <div style="margin-top:12px;text-align:center;padding:12px;border-radius:var(--app-radius-lg);background:var(--app-glass-hover)">
-                <p style="font-size:12px;color:var(--app-text-dim)">Estatísticas serão atualizadas após a rodada 1</p>
-            </div>
-        </div>
+    const extratoComLancamentos = {
+        ...extrato,
+        lancamentosIniciais,
+        rodadas: [], // força modo pré-temporada
+    };
 
-    `;
+    container.innerHTML = renderThermalTicket(extratoComLancamentos, acertos, ligaId, { isPreTemporadaMode: true });
 }
 
 // =====================================================================
 // EXPORTED: ENTRY POINT
 // =====================================================================
+
 export async function renderizarExtratoParticipante(extrato, participanteId) {
     const container = document.getElementById("fluxoFinanceiroContent");
     if (!container) {
@@ -1043,13 +499,12 @@ export async function renderizarExtratoParticipante(extrato, participanteId) {
         return;
     }
 
-    // ✅ v11.1 FIX: Popular ligaConfigCache com dados que vêm do backend
-    // Isso corrige bug onde posições > 32 eram classificadas como "neutro"
-    // porque o fallback de 32 participantes era usado quando ligaConfigCache estava null
+    // ✅ Popular ligaConfigCache (zone classification — preservado da v11)
     if (extrato.ligaConfig?.zonaConfig) {
         const zonaConfig = extrato.ligaConfig.zonaConfig;
         ligaConfigCache = {
             liga_id: extrato.ligaId || window.PARTICIPANTE_IDS?.ligaId,
+            liga_nome: extrato.ligaConfig.nome || extrato.ligaConfig.liga_nome,
             ranking_rodada: {
                 total_participantes: zonaConfig.totalParticipantes || DEFAULT_TOTAL_PARTICIPANTES,
                 faixas: zonaConfig.faixas || null,
@@ -1061,8 +516,6 @@ export async function renderizarExtratoParticipante(extrato, participanteId) {
         window.ligaConfigCache = ligaConfigCache;
         if (window.Log) Log.debug("[EXTRATO-UI] ✅ ligaConfigCache populado:", { totalParticipantes: zonaConfig.totalParticipantes });
     } else {
-        // ✅ v11.4 FIX: Fallback — buscar config da liga via API quando ligaConfig não vem no extrato
-        // Cobre: path de cálculo (fluxoFinanceiroController), caches antigos, e dados do IndexedDB
         const ligaId = extrato.ligaId || window.PARTICIPANTE_IDS?.ligaId;
         if (ligaId && (!ligaConfigCache || ligaConfigCache.liga_id !== ligaId)) {
             await fetchLigaConfigSilent(ligaId);
@@ -1079,7 +532,10 @@ export async function renderizarExtratoParticipante(extrato, participanteId) {
     const temporadaAtual = CONFIG.CURRENT_SEASON || 2026;
     const visualizandoHistorico = temporadaSelecionada && temporadaSelecionada < temporadaAtual;
 
-    if (window.Log) Log.info("[EXTRATO-UI] 📊 Status:", { renovado, preTemporada, rodadas: extrato.rodadas.length, temporadaSelecionada, visualizandoHistorico });
+    if (window.Log) Log.info("[EXTRATO-UI] 📊 Status:", {
+        renovado, preTemporada, rodadas: extrato.rodadas.length,
+        temporadaSelecionada, visualizandoHistorico
+    });
 
     window.extratoAtual = extrato;
 
@@ -1088,624 +544,97 @@ export async function renderizarExtratoParticipante(extrato, participanteId) {
     } else {
         window.renderizarConteudoCompleto(container, extrato);
     }
-
-    setTimeout(() => {
-        if (!visualizandoHistorico && renovado && preTemporada) {
-            window.renderizarGraficoPreTemporada();
-        } else {
-            renderizarGraficoEvolucao(extrato.rodadas);
-        }
-        configurarFiltrosGrafico(extrato.rodadas);
-        configurarBotaoRefresh();
-    }, 100);
 }
 
 // =====================================================================
-// CHART: GRÁFICO EVOLUÇÃO
+// ERRO STATE
 // =====================================================================
-function renderizarGraficoEvolucao(rodadas, range = "all") {
-    const path = document.getElementById("graficoPath");
-    const area = document.getElementById("graficoArea");
-    const labels = document.getElementById("graficoLabels");
-    if (!path || !area || !labels) return;
-
-    let dadosOrdenados = [...rodadas].sort((a, b) => a.rodada - b.rodada);
-    if (range !== "all") dadosOrdenados = dadosOrdenados.slice(-parseInt(range));
-    if (dadosOrdenados.length === 0) { path.setAttribute("d", ""); area.setAttribute("d", ""); labels.innerHTML = ""; return; }
-
-    let saldoAcumulado = 0;
-    const pontos = dadosOrdenados.map(r => {
-        saldoAcumulado += (r.bonusOnus || 0) + (r.pontosCorridos || 0) + (r.mataMata || 0) + (r.top10 || 0) + (r.restaUm || 0);
-        return { rodada: r.rodada, saldo: saldoAcumulado };
-    });
-
-    const valores = pontos.map(p => p.saldo);
-    const min = Math.min(...valores, 0);
-    const max = Math.max(...valores, 0);
-    const range2 = Math.max(Math.abs(max), Math.abs(min)) || 1;
-    const width = 300, height = 140, paddingY = 10;
-
-    const mapY = val => {
-        const normalized = (val - min) / (range2 * 2 || 1);
-        return height - paddingY - normalized * (height - paddingY * 2);
-    };
-
-    let pathD = "", areaD = "";
-    pontos.forEach((p, i) => {
-        const x = (i / (pontos.length - 1 || 1)) * width;
-        const y = mapY(p.saldo);
-        if (i === 0) { pathD = `M ${x} ${y}`; areaD = `M ${x} ${height - paddingY}`; }
-        pathD += ` L ${x} ${y}`;
-        areaD += ` L ${x} ${y}`;
-    });
-    if (pontos.length > 0) areaD += ` L ${width} ${height - paddingY} Z`;
-
-    // Color based on final saldo
-    const finalSaldo = pontos[pontos.length - 1].saldo;
-    const strokeColor = 'var(--app-primary)'; // Orange identity
-    path.setAttribute("d", pathD);
-    path.setAttribute("stroke", strokeColor);
-    area.setAttribute("d", areaD);
-
-    const step = Math.ceil(pontos.length / 6);
-    labels.innerHTML = pontos.filter((_, i) => i % step === 0 || i === pontos.length - 1).map(p => `<span>R${p.rodada}</span>`).join("");
-}
-
-window.renderizarGraficoPreTemporada = function() {
-    const path = document.getElementById("graficoPath");
-    const area = document.getElementById("graficoArea");
-    const labels = document.getElementById("graficoLabels");
-    if (!path || !area || !labels) return;
-
-    const width = 300, height = 140, centerY = height / 2;
-    const startX = 10, endX = width - 10;
-    const pathD = `M ${startX} ${centerY} C ${startX + 30} ${centerY}, ${endX - 30} ${centerY}, ${endX} ${centerY}`;
-    const areaD = `${pathD} L ${endX} ${height} L ${startX} ${height} Z`;
-
-    path.setAttribute("d", pathD);
-    area.setAttribute("d", areaD);
-
-    const rodadasMarcadas = [1, 8, 15, 22, 29, 36, 38];
-    labels.innerHTML = rodadasMarcadas.map(rodada => {
-        const x = startX + ((endX - startX) * (rodada - 1) / 37);
-        return `<span style="position:absolute;left:${(x / width) * 100}%;transform:translateX(-50%)">R${rodada}</span>`;
-    }).join("");
-};
-
-// =====================================================================
-// CHART FILTERS
-// =====================================================================
-function configurarFiltrosGrafico(rodadas) {
-    const btns = document.querySelectorAll(".filtro-btn");
-    btns.forEach(btn => {
-        btn.addEventListener("click", () => {
-            btns.forEach(b => { b.classList.remove("extrato-chart__filter-btn--active"); });
-            btn.classList.add("extrato-chart__filter-btn--active");
-            renderizarGraficoEvolucao(rodadas, btn.dataset.range);
-        });
-    });
-}
-
-function configurarBotaoRefresh() {
-    const btn = document.getElementById("btnRefreshExtrato");
-    if (btn) {
-        btn.addEventListener("click", () => {
-            if (window.forcarRefreshExtratoParticipante) window.forcarRefreshExtratoParticipante();
-        });
-    }
-}
-
-// =====================================================================
-// TIMELINE FILTERS (v3 - compativel com layout compacto)
-// =====================================================================
-function configurarFiltrosTimeline() {
-    const btns = document.querySelectorAll('[data-tl-filter]');
-    btns.forEach(btn => {
-        btn.addEventListener('click', () => {
-            btns.forEach(b => b.classList.remove('extrato-timeline__filter-btn--active'));
-            btn.classList.add('extrato-timeline__filter-btn--active');
-
-            const filter = btn.dataset.tlFilter;
-
-            // Seleciona tanto layout antigo quanto novo
-            const rows = document.querySelectorAll('.extrato-tl__row, .extrato-timeline__group');
-            const rowDetails = document.querySelectorAll('.extrato-tl__row-details');
-
-            rows.forEach((row, idx) => {
-                let show = true;
-
-                // Novo layout compacto: usa data-saldo
-                if (row.classList.contains('extrato-tl__row')) {
-                    const saldo = parseFloat(row.dataset.saldo) || 0;
-                    const rodada = row.dataset.rodada;
-
-                    if (filter === 'credito') {
-                        show = saldo > 0;
-                    } else if (filter === 'debito') {
-                        show = saldo < 0;
-                    } else if (filter === 'acertos') {
-                        show = !rodada; // Acertos nao tem rodada
-                    }
-
-                    row.style.display = show ? '' : 'none';
-                    // Esconder tambem os detalhes correspondentes
-                    const details = row.nextElementSibling;
-                    if (details && details.classList.contains('extrato-tl__row-details')) {
-                        details.style.display = show ? '' : 'none';
-                        if (!show) details.classList.remove('extrato-tl__row-details--open');
-                    }
-                }
-                // Layout antigo (fallback)
-                else {
-                    const label = row.querySelector('.extrato-timeline__group-label')?.textContent?.toLowerCase() || '';
-                    if (filter === 'credito') {
-                        const total = row.querySelector('.extrato-timeline__group-total');
-                        show = total && total.textContent.includes('+');
-                    } else if (filter === 'debito') {
-                        const total = row.querySelector('.extrato-timeline__group-total');
-                        show = total && total.textContent.includes('-');
-                    } else if (filter === 'acertos') {
-                        show = label.includes('acerto');
-                    }
-                    row.style.display = show ? '' : 'none';
-                }
-            });
-        });
-    });
-}
-
-// =====================================================================
-// MINI REFRESH ACERTOS
-// =====================================================================
-window.refreshAcertosBottomSheet = async function() {
-    const btn = document.getElementById('btnRefreshAcertos');
-    const iconEl = btn?.querySelector('.material-icons');
-    const ligaId = window.PARTICIPANTE_IDS?.ligaId || window.participanteData?.ligaId;
-    const timeId = window.PARTICIPANTE_IDS?.timeId || window.participanteData?.timeId;
-    if (!ligaId || !timeId) return;
-
-    if (btn) btn.disabled = true;
-    if (iconEl) iconEl.classList.add('animate-spin');
-
-    try {
-        const CONFIG = window.ParticipanteConfig || {};
-        const temporada = CONFIG.getFinancialSeason ? CONFIG.getFinancialSeason() : (CONFIG.CURRENT_SEASON || 2026);
-        const url = `/api/extrato-cache/${ligaId}/times/${timeId}/cache?temporada=${temporada}`;
-        const response = await fetch(url);
-        if (!response.ok) throw new Error(`Erro: ${response.status}`);
-
-        const data = await response.json();
-        const acertos = data.acertos || { lista: [], resumo: {} };
-        const resumo = data.resumo || {};
-        const saldoAcertosAtualizado = acertos.resumo?.saldo ?? resumo.saldo_acertos ?? 0;
-        const saldoTemporadaAtual = resumo.saldo_temporada ?? resumo.saldo_final ?? resumo.saldo ?? 0;
-        const saldoAtualCalculado = saldoTemporadaAtual + saldoAcertosAtualizado;
-
-        if (window.extratoAtual) {
-            window.extratoAtual.acertos = acertos;
-            window.extratoAtual.resumo = { ...window.extratoAtual.resumo, ...resumo, saldo_acertos: saldoAcertosAtualizado, saldo_atual: saldoAtualCalculado };
-        }
-
-        if (window.ParticipanteCache) {
-            const cacheAtual = await window.ParticipanteCache.getExtratoAsync?.(ligaId, timeId) || window.ParticipanteCache.getExtrato?.(ligaId, timeId);
-            if (cacheAtual) {
-                cacheAtual.acertos = acertos;
-                cacheAtual.resumo = { ...cacheAtual.resumo, ...resumo, saldo_acertos: saldoAcertosAtualizado, saldo_atual: saldoAtualCalculado };
-                window.ParticipanteCache.setExtrato(ligaId, timeId, cacheAtual);
-            }
-        }
-
-        const container = document.getElementById("fluxoFinanceiroContent");
-        if (container && window.extratoAtual) {
-            window.renderizarConteudoCompleto(container, window.extratoAtual);
-        }
-        mostrarToast('Acertos atualizados!', 'success');
-    } catch (error) {
-        if (window.Log) Log.error("[EXTRATO-UI] ❌ Erro no refresh:", error);
-        mostrarToast('Erro ao atualizar', 'error');
-    } finally {
-        if (btn) btn.disabled = false;
-        if (iconEl) iconEl.classList.remove('animate-spin');
-    }
-};
-
-// =====================================================================
-// DETALHAMENTO GANHOS/PERDAS (mantido do v10.9)
-// =====================================================================
-window.mostrarDetalhamentoGanhos = function(event) {
-    if (event) { event.preventDefault(); event.stopPropagation(); }
-    try { mostrarPopupDetalhamento(true); } catch (e) { if (window.Log) Log.error('[EXTRATO-UI] ❌', e); }
-};
-
-window.mostrarDetalhamentoPerdas = function(event) {
-    if (event) { event.preventDefault(); event.stopPropagation(); }
-    try { mostrarPopupDetalhamento(false); } catch (e) { if (window.Log) Log.error('[EXTRATO-UI] ❌', e); }
-};
-
-function mostrarPopupDetalhamento(isGanhos) {
-    const extrato = window.extratoAtual;
-    if (!extrato || !extrato.resumo) { mostrarToast('Aguarde o carregamento', 'error'); return; }
-
-    const titulo = isGanhos ? "Detalhamento de Créditos" : "Detalhamento de Débitos";
-    const icon = isGanhos ? "arrow_upward" : "arrow_downward";
-    const resumo = extrato.resumo || {};
-    const categorias = {};
-    const ligaId = window.ligaIdAtual || "";
-
-    const bonus = resumo.bonus || 0;
-    const onus = resumo.onus || 0;
-    const pontosCorridos = resumo.pontosCorridos || 0;
-    const mataMata = resumo.mataMata || 0;
-    const top10 = resumo.top10 || 0;
-    const somaGanhos = resumo.totalGanhos || 0;
-    const somaPerdas = Math.abs(resumo.totalPerdas || 0);
-
-    const isInativo = extrato.inativo || false;
-    const rodadaDesistencia = extrato.rodadaDesistencia || null;
-    const rodadaLimite = isInativo && rodadaDesistencia ? rodadaDesistencia - 1 : 999;
-
-    let rodadasComGanho = 0, rodadasComPerda = 0, totalMito = 0, totalMico = 0, totalZonaCredito = 0, totalZonaDebito = 0;
-
-    if (extrato.rodadas && Array.isArray(extrato.rodadas)) {
-        extrato.rodadas.filter(r => r.rodada <= rodadaLimite).forEach(r => {
-            const faixas = getFaixasParaRodada(ligaId, r.rodada);
-            const saldo = (r.bonusOnus || 0) + (r.pontosCorridos || 0) + (r.mataMata || 0) + (r.top10 || 0) + (r.restaUm || 0);
-            if (saldo > 0) rodadasComGanho++;
-            if (saldo < 0) rodadasComPerda++;
-            if (r.top10 > 0) totalMito++;
-            if (r.top10 < 0) totalMico++;
-            if (r.posicao && r.posicao <= faixas.credito.fim) totalZonaCredito++;
-            if (r.posicao && r.posicao >= faixas.debito.inicio) totalZonaDebito++;
-        });
-    }
-
-    if (isGanhos) {
-        if (bonus > 0) addCategoria(categorias, "Zona de Ganho", bonus, "Total", "add_circle");
-        if (pontosCorridos > 0) addCategoria(categorias, "Pontos Corridos", pontosCorridos, "Total", "sports_soccer");
-        if (mataMata > 0) addCategoria(categorias, "Mata-Mata", mataMata, "Total", "emoji_events");
-        if (top10 > 0) addCategoria(categorias, "Top 10 (MITO)", top10, "Total", "star");
-        const saldoAnteriorGanho = resumo.saldoAnteriorTransferido || 0;
-        if (saldoAnteriorGanho > 0) addCategoria(categorias, "Crédito Temporada Anterior", saldoAnteriorGanho, "Transferido", "savings");
-    } else {
-        const taxaInscricao = resumo.taxaInscricao || 0;
-        if (taxaInscricao > 0) addCategoria(categorias, "Inscrição Temporada", taxaInscricao, "Inscrição", "receipt_long");
-        const saldoAnterior = resumo.saldoAnteriorTransferido || 0;
-        if (saldoAnterior < 0) addCategoria(categorias, "Dívida Temporada Anterior", Math.abs(saldoAnterior), "Transferido", "history");
-        if (onus < 0) addCategoria(categorias, "Zona de Perda", Math.abs(onus), "Total", "remove_circle");
-        if (pontosCorridos < 0) addCategoria(categorias, "Pontos Corridos", Math.abs(pontosCorridos), "Total", "sports_soccer");
-        if (mataMata < 0) addCategoria(categorias, "Mata-Mata", Math.abs(mataMata), "Total", "sports_mma");
-        if (top10 < 0) addCategoria(categorias, "Top 10 (MICO)", Math.abs(top10), "Total", "sentiment_very_dissatisfied");
-    }
-
-    const camposManuais = extrato.camposManuais || extrato.camposEditaveis || [];
-    if (Array.isArray(camposManuais) && camposManuais.length > 0) {
-        camposManuais.forEach(campo => {
-            const valor = parseFloat(campo.valor) || 0;
-            const nome = campo.nome || "Ajuste Manual";
-            if (isGanhos && valor > 0) addCategoria(categorias, nome, valor, "Manual", "edit");
-            else if (!isGanhos && valor < 0) addCategoria(categorias, nome, Math.abs(valor), "Manual", "edit");
-        });
-    }
-
-    const total = isGanhos ? somaGanhos : somaPerdas;
-    const mediaGanho = rodadasComGanho > 0 ? somaGanhos / rodadasComGanho : 0;
-    const mediaPerda = rodadasComPerda > 0 ? somaPerdas / rodadasComPerda : 0;
-
-    const categoriasArray = Object.values(categorias)
-        .map(cat => ({ ...cat, percentual: total > 0 ? (cat.valor / total) * 100 : 0 }))
-        .sort((a, b) => b.valor - a.valor);
-
-    document.getElementById("popupDetalhamento")?.remove();
-
-    const corPrincipal = isGanhos ? 'var(--app-success-light)' : 'var(--app-danger-light)';
-    const corBg = isGanhos ? 'rgba(16,185,129,0.12)' : 'rgba(239,68,68,0.12)';
-    const corBar = isGanhos ? 'var(--app-success)' : 'var(--app-danger)';
-
-    const html = `
-        <div id="popupDetalhamento" onclick="this.remove()" class="fixed inset-0 z-50 flex items-center justify-center" style="background:rgba(0,0,0,0.7);backdrop-filter:blur(8px);padding:16px">
-            <div onclick="event.stopPropagation()" style="background:var(--app-bg-elevated,#1c1c1e);border-radius:var(--app-radius-2xl);width:100%;max-width:400px;max-height:85vh;overflow:hidden;box-shadow:0 24px 48px rgba(0,0,0,0.5)">
-                <div style="padding:16px;border-bottom:1px solid var(--app-glass-border)">
-                    <div style="display:flex;justify-content:space-between;align-items:start;margin-bottom:12px">
-                        <h3 style="font-size:16px;font-weight:700;color:var(--app-text-primary);display:flex;align-items:center;gap:8px">
-                            <span class="material-icons" style="color:${corPrincipal}">${icon}</span>
-                            ${titulo}
-                        </h3>
-                        <button style="color:var(--app-text-dim);background:none;border:none;cursor:pointer" onclick="document.getElementById('popupDetalhamento').remove()">
-                            <span class="material-icons">close</span>
-                        </button>
-                    </div>
-                    <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:8px">
-                        <div style="text-align:center"><p style="font-size:10px;color:var(--app-text-dim)">Rodadas</p><p style="font-size:18px;font-weight:700;color:var(--app-text-primary)">${isGanhos ? rodadasComGanho : rodadasComPerda}</p></div>
-                        <div style="text-align:center"><p style="font-size:10px;color:var(--app-text-dim)">Média</p><p style="font-size:18px;font-weight:700;color:var(--app-text-primary)">${(isGanhos ? mediaGanho : mediaPerda).toFixed(2).replace('.', ',')}</p></div>
-                        <div style="text-align:center"><p style="font-size:10px;color:var(--app-text-dim)">${isGanhos ? 'Mitos' : 'Micos'}</p><p style="font-size:18px;font-weight:700;color:var(--app-text-primary)">${isGanhos ? totalMito : totalMico}x</p></div>
-                        <div style="text-align:center"><p style="font-size:10px;color:var(--app-text-dim)">${isGanhos ? 'Zona G' : 'Zona Z'}</p><p style="font-size:18px;font-weight:700;color:var(--app-text-primary)">${isGanhos ? totalZonaCredito : totalZonaDebito}x</p></div>
-                    </div>
-                </div>
-                <div style="padding:16px;overflow-y:auto;max-height:50vh;display:flex;flex-direction:column;gap:12px">
-                    ${categoriasArray.length === 0
-                        ? `<div style="text-align:center;padding:32px 0;color:var(--app-text-dim)"><span class="material-icons" style="font-size:36px;display:block;margin-bottom:8px">inbox</span>Nenhum registro encontrado</div>`
-                        : categoriasArray.map(cat => `
-                            <div style="background:var(--app-glass-hover);border-radius:var(--app-radius-lg);padding:12px">
-                                <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
-                                    <div style="display:flex;align-items:center;gap:8px">
-                                        <div style="width:32px;height:32px;border-radius:var(--app-radius-md);display:flex;align-items:center;justify-content:center;background:${corBg}">
-                                            <span class="material-icons" style="font-size:16px;color:${corPrincipal}">${cat.icon}</span>
-                                        </div>
-                                        <span style="font-size:14px;font-weight:500;color:var(--app-text-primary)">${cat.nome}</span>
-                                    </div>
-                                    <span style="font-family:'JetBrains Mono',monospace;font-size:16px;font-weight:700;color:${corPrincipal}">R$ ${cat.valor.toFixed(2).replace('.', ',')}</span>
-                                </div>
-                                <div style="height:6px;background:var(--app-glass-border);border-radius:9999px;overflow:hidden;margin-bottom:4px">
-                                    <div style="height:100%;border-radius:9999px;background:${corBar};width:${cat.percentual}%"></div>
-                                </div>
-                                <div style="display:flex;justify-content:space-between;font-size:10px;color:var(--app-text-dim)">
-                                    <span>${Array.isArray(cat.rodadas) ? cat.rodadas.length + ' rodada(s)' : cat.rodadas}</span>
-                                    <span>${cat.percentual.toFixed(1)}%</span>
-                                </div>
-                            </div>
-                        `).join('')
-                    }
-                    <div style="border-radius:var(--app-radius-lg);padding:16px;background:${corBg}">
-                        <div style="display:flex;justify-content:space-between;align-items:center">
-                            <span style="display:flex;align-items:center;gap:8px;font-size:14px;font-weight:700;color:var(--app-text-primary)">
-                                <span class="material-icons" style="color:${corPrincipal}">account_balance_wallet</span>
-                                TOTAL ${isGanhos ? 'CRÉDITOS' : 'DÉBITOS'}
-                            </span>
-                            <span style="font-family:'JetBrains Mono',monospace;font-size:20px;font-weight:800;color:${corPrincipal}">R$ ${total.toFixed(2).replace('.', ',')}</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    `;
-    document.body.insertAdjacentHTML("beforeend", html);
-}
-
-function addCategoria(obj, nome, valor, rodada, icon) {
-    if (!obj[nome]) obj[nome] = { nome, valor: 0, rodadas: [], icon };
-    obj[nome].valor += valor;
-    if (rodada !== "Manual") obj[nome].rodadas.push(rodada);
-    else obj[nome].rodadas = "Ajuste manual";
-}
-
-// =====================================================================
-// UTILS: TOASTS
-// =====================================================================
-function mostrarToast(mensagem, tipo = 'success') {
-    const toast = document.createElement('div');
-    const bg = tipo === 'success' ? 'var(--app-success)' : 'var(--app-danger)';
-    toast.style.cssText = `position:fixed;bottom:80px;left:50%;transform:translateX(-50%);background:${bg};color:white;padding:8px 20px;border-radius:9999px;font-size:14px;font-weight:500;z-index:9999;animation:fadeIn 0.2s ease`;
-    toast.textContent = mensagem;
-    document.body.appendChild(toast);
-    setTimeout(() => toast.remove(), 2500);
-}
-
 function renderizarErro() {
     return `
-        <div class="extrato-empty">
-            <span class="material-icons extrato-empty__icon">error_outline</span>
-            <p class="extrato-empty__title">Erro ao carregar extrato</p>
-            <p class="extrato-empty__text">Tente novamente em alguns instantes</p>
-            <button onclick="window.forcarRefreshExtratoParticipante()" style="
-                margin-top:16px;padding:12px 24px;
-                background:var(--app-primary);color:white;
-                border:none;border-radius:var(--app-radius-lg);
-                font-weight:600;font-size:14px;cursor:pointer;
-            ">Tentar Novamente</button>
-        </div>
+        <section class="thermal-stage">
+            <article class="thermal-ticket" role="alert">
+                <header class="thermal-ticket__header">
+                    <p class="thermal-ticket__store">Super Cartola Manager</p>
+                    <h1 class="thermal-ticket__title"><span>Extrato</span><span>Erro</span></h1>
+                </header>
+                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">* * * * * * * * * * * * * *</div>
+                <div class="thermal-ticket__empty">
+                    <p style="font-weight:700;margin-bottom:8px">Erro ao carregar extrato</p>
+                    <p>Tente novamente em alguns instantes</p>
+                    <button onclick="window.forcarRefreshExtratoParticipante && window.forcarRefreshExtratoParticipante()" style="
+                        margin-top:16px;padding:10px 20px;
+                        background:var(--thermal-ink);color:var(--thermal-paper);
+                        border:none;border-radius:2px;
+                        font-family:inherit;font-size:11px;font-weight:700;
+                        letter-spacing:2px;text-transform:uppercase;cursor:pointer;
+                    ">Tentar Novamente</button>
+                </div>
+            </article>
+        </section>
     `;
 }
 
 // =====================================================================
-// ✅ v11.1: PROJEÇÃO FINANCEIRA EM TEMPO REAL
-// Card exibido durante rodada em andamento (status_mercado === 2)
+// PROJEÇÃO FINANCEIRA EM TEMPO REAL
+// Card exibido durante rodada em andamento (status_mercado === 2).
+// Importado por participante-extrato.js — manter assinatura.
+// Insere card como overlay informacional ABOVE do ticket no container principal.
 // =====================================================================
 
 export function renderizarProjecaoFinanceira(projecaoData) {
     if (!projecaoData || !projecaoData.projecao) return;
 
-    // Encontrar ou criar container da projeção
     let card = document.getElementById("projecaoFinanceiraCard");
 
     if (!card) {
-        // Inserir após o hero card
-        const heroCard = document.querySelector(".extrato-hero");
-        if (heroCard && heroCard.parentNode) {
-            card = document.createElement("div");
-            card.id = "projecaoFinanceiraCard";
-            heroCard.parentNode.insertBefore(card, heroCard.nextSibling);
-        } else {
-            // Fallback: inserir no topo do container principal
-            const mainContainer = document.getElementById("fluxoFinanceiroContent");
-            if (!mainContainer) return;
-            card = document.createElement("div");
-            card.id = "projecaoFinanceiraCard";
-            mainContainer.insertBefore(card, mainContainer.firstChild);
-        }
+        const mainContainer = document.getElementById("fluxoFinanceiroContent");
+        if (!mainContainer) return;
+        card = document.createElement("div");
+        card.id = "projecaoFinanceiraCard";
+        // Inserir antes do ticket térmico
+        mainContainer.insertBefore(card, mainContainer.firstChild);
     }
 
     const { rodada, time, financeiro, saldo, atualizado_em } = projecaoData;
-    const impacto = financeiro?.impactoProjetado || 0;
-    const impactoPositivo = impacto > 0;
-    const impactoNegativo = impacto < 0;
-    const impactoCor = impactoPositivo ? 'var(--app-success)' : impactoNegativo ? 'var(--app-danger)' : 'var(--app-text-dim)';
-    const impactoSinal = impactoPositivo ? '+' : '';
-
     const horaAtualizada = atualizado_em
         ? new Date(atualizado_em).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
         : '--:--';
 
-    // Banco info
-    const banco = financeiro?.banco;
-    const bancoValor = banco?.valor || 0;
-    const bancoCor = bancoValor > 0 ? 'var(--app-success-light)' : bancoValor < 0 ? 'var(--app-danger-light)' : 'var(--app-text-dim)';
-
-    // PC info
-    const pc = financeiro?.pontosCorridos;
-    const pcValor = pc?.valor || 0;
-    const pcCor = pcValor > 0 ? 'var(--app-success-light)' : pcValor < 0 ? 'var(--app-danger-light)' : 'var(--app-text-dim)';
-
-    // Saldo projetado
     const saldoProjetado = saldo?.projetado || 0;
-    const saldoProjetadoCor = saldoProjetado >= 0 ? 'var(--app-success-light)' : 'var(--app-danger-light)';
+    const saldoCor = saldoProjetado >= 0 ? 'var(--app-success-light, #22c55e)' : 'var(--app-danger-light, #f87171)';
+    const sinal = saldoProjetado > 0 ? '+' : saldoProjetado < 0 ? '−' : '';
+    const valorAbs = Math.abs(saldoProjetado).toFixed(2).replace('.', ',');
+    const posParcial = time?.posicao_parcial || '-';
+    const nomeTime = time?.nome_time || 'Meu Time';
 
     card.innerHTML = `
         <div style="
-            margin: 12px 0;
-            padding: 16px;
-            background: linear-gradient(135deg, rgba(34, 197, 94, 0.06) 0%, rgba(34, 197, 94, 0.02) 100%);
-            border: 1.5px dashed rgba(34, 197, 94, 0.35);
-            border-radius: var(--app-radius-xl, 16px);
-            position: relative;
-            overflow: hidden;
+            margin: 16px 12px 0;
+            padding: 14px 16px;
+            background: linear-gradient(135deg, rgba(34, 197, 94, 0.08) 0%, rgba(34, 197, 94, 0.03) 100%);
+            border: 1.5px dashed rgba(34, 197, 94, 0.4);
+            border-radius: 12px;
+            color: var(--app-text-primary, #e5e5e5);
+            font-family: 'Inter', sans-serif;
         ">
-            <!-- Header -->
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-                <div style="display: flex; align-items: center; gap: 8px;">
-                    <span style="
-                        display: inline-block;
-                        width: 8px; height: 8px;
-                        background: #22c55e;
-                        border-radius: 50%;
-                        animation: projecaoPulse 2s ease-in-out infinite;
-                    "></span>
-                    <span style="
-                        font-size: 11px;
-                        font-weight: 700;
-                        text-transform: uppercase;
-                        letter-spacing: 0.5px;
-                        color: #22c55e;
-                    ">Projecao R${rodada} ao vivo</span>
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px">
+                <div style="display:flex;align-items:center;gap:8px">
+                    <span style="display:inline-block;width:8px;height:8px;background:#22c55e;border-radius:50%;animation:app-pulse 2s ease-in-out infinite"></span>
+                    <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;color:#22c55e">
+                        Projeção R${rodada} ao vivo
+                    </span>
                 </div>
-                <span style="font-size: 10px; color: var(--app-text-dim, #6b7280);">
-                    ${horaAtualizada}
-                </span>
+                <span style="font-size:10px;color:var(--app-text-dim,#9ca3af)">${horaAtualizada}</span>
             </div>
-
-            <!-- Position + Points -->
-            <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 14px;">
-                <div style="
-                    width: 44px; height: 44px;
-                    border-radius: var(--app-radius-lg, 12px);
-                    background: rgba(34, 197, 94, 0.12);
-                    display: flex; align-items: center; justify-content: center;
-                    font-family: 'JetBrains Mono', monospace;
-                    font-size: 18px; font-weight: 800;
-                    color: #22c55e;
-                ">${time?.posicao_parcial || '-'}°</div>
+            <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
                 <div>
-                    <div style="font-size: 13px; font-weight: 600; color: var(--app-text-primary, #e5e5e5);">
-                        ${time?.nome_time || 'Meu Time'}
-                    </div>
-                    <div style="font-size: 11px; color: var(--app-text-dim, #6b7280);">
-                        ${(Math.trunc((time?.pontos_parciais || 0) * 100) / 100).toFixed(2).replace('.', ',')} pts parciais
-                        &middot; ${time?.total_times || '?'} times
-                    </div>
+                    <div style="font-size:13px;font-weight:600">${safeEscapeHtml(nomeTime)}</div>
+                    <div style="font-size:10px;color:var(--app-text-dim,#9ca3af);margin-top:2px">Posição parcial: ${posParcial}º</div>
                 </div>
-            </div>
-
-            <!-- Financial Breakdown -->
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 12px;">
-                <!-- Banco -->
-                <div style="
-                    background: var(--app-glass-bg, rgba(255,255,255,0.04));
-                    border-radius: var(--app-radius-md, 8px);
-                    padding: 10px;
-                ">
-                    <div style="font-size: 10px; color: var(--app-text-dim, #6b7280); margin-bottom: 4px;">
-                        Banco (${banco?.posicao || '-'}° lugar)
-                    </div>
-                    <div style="
-                        font-family: 'JetBrains Mono', monospace;
-                        font-size: 16px; font-weight: 700;
-                        color: ${bancoCor};
-                    ">${bancoValor >= 0 ? '+' : ''}${bancoValor.toFixed(2).replace('.', ',')}</div>
+                <div style="font-family:'JetBrains Mono',monospace;font-size:18px;font-weight:800;color:${saldoCor}">
+                    ${sinal} R$ ${valorAbs}
                 </div>
-
-                <!-- Pontos Corridos -->
-                <div style="
-                    background: var(--app-glass-bg, rgba(255,255,255,0.04));
-                    border-radius: var(--app-radius-md, 8px);
-                    padding: 10px;
-                ">
-                    <div style="font-size: 10px; color: var(--app-text-dim, #6b7280); margin-bottom: 4px;">
-                        ${pc ? 'Pontos Corridos' : 'PC (inativo)'}
-                    </div>
-                    <div style="
-                        font-family: 'JetBrains Mono', monospace;
-                        font-size: 16px; font-weight: 700;
-                        color: ${pc ? pcCor : 'var(--app-text-dim, #6b7280)'};
-                    ">${pc ? `${pcValor >= 0 ? '+' : ''}${pcValor.toFixed(2).replace('.', ',')}` : '--'}</div>
-                    ${pc?.oponente ? `<div style="font-size: 9px; color: var(--app-text-dim, #6b7280); margin-top: 2px;">vs ${pc.oponente}</div>` : ''}
-                </div>
-            </div>
-
-            <!-- Impact Total -->
-            <div style="
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                padding: 10px 12px;
-                background: ${impactoPositivo ? 'rgba(34, 197, 94, 0.1)' : impactoNegativo ? 'rgba(239, 68, 68, 0.1)' : 'var(--app-glass-bg, rgba(255,255,255,0.04))'};
-                border-radius: var(--app-radius-md, 8px);
-            ">
-                <div style="display: flex; align-items: center; gap: 6px;">
-                    <span class="material-icons" style="font-size: 16px; color: ${impactoCor};">
-                        ${impactoPositivo ? 'trending_up' : impactoNegativo ? 'trending_down' : 'remove'}
-                    </span>
-                    <span style="font-size: 12px; font-weight: 600; color: var(--app-text-primary, #e5e5e5);">
-                        Impacto projetado
-                    </span>
-                </div>
-                <span style="
-                    font-family: 'JetBrains Mono', monospace;
-                    font-size: 18px; font-weight: 800;
-                    color: ${impactoCor};
-                ">${impactoSinal}${impacto.toFixed(2).replace('.', ',')}</span>
-            </div>
-
-            <!-- Disclaimer -->
-            <div style="margin-top: 10px; font-size: 9px; color: var(--app-text-dim, #6b7280); text-align: center; opacity: 0.7;">
-                Valores provisorios baseados em parciais. Atualiza a cada 60s. Resultado final apos consolidacao.
             </div>
         </div>
-
-        <style>
-            @keyframes projecaoPulse {
-                0%, 100% { opacity: 1; transform: scale(1); }
-                50% { opacity: 0.4; transform: scale(1.3); }
-            }
-        </style>
     `;
-
-    // ✅ v11.3: Atualizar hero card com saldo projetado (se hero existe)
-    const heroValorEl = document.querySelector('.extrato-hero__valor');
-    const heroLabelEl = document.querySelector('.extrato-hero__label');
-    if (heroValorEl && saldo?.projetado !== undefined) {
-        const sp = saldo.projetado;
-        const spPositivo = sp > 0;
-        const spNegativo = sp < 0;
-
-        // Atualizar valor no hero
-        heroValorEl.textContent = `${spNegativo ? '-' : spPositivo ? '+' : ''}R$ ${Math.abs(sp).toFixed(2).replace('.', ',')}`;
-
-        // Atualizar classes de cor
-        heroValorEl.classList.remove('extrato-hero__valor--positive', 'extrato-hero__valor--negative', 'extrato-hero__valor--zero');
-        heroValorEl.classList.add(spPositivo ? 'extrato-hero__valor--positive' : spNegativo ? 'extrato-hero__valor--negative' : 'extrato-hero__valor--zero');
-
-        // Atualizar hero container classes
-        const heroEl = document.querySelector('.extrato-hero');
-        if (heroEl) {
-            heroEl.classList.remove('extrato-hero--positive', 'extrato-hero--negative', 'extrato-hero--zero');
-            heroEl.classList.add(spPositivo ? 'extrato-hero--positive' : spNegativo ? 'extrato-hero--negative' : 'extrato-hero--zero');
-        }
-
-        // Indicar que é projeção no label
-        if (heroLabelEl && !heroLabelEl.dataset.originalLabel) {
-            heroLabelEl.dataset.originalLabel = heroLabelEl.textContent;
-            heroLabelEl.innerHTML = `Saldo Projetado <span style="display:inline-block;width:6px;height:6px;background:#22c55e;border-radius:50%;margin-left:4px;animation:projecaoPulse 2s ease-in-out infinite;vertical-align:middle;"></span>`;
-        }
-    }
 }
-
-if (window.Log) Log.info("[EXTRATO-UI] ✅ Módulo v11.1 carregado (BANK DIGITAL + PROJEÇÃO AO VIVO)");


### PR DESCRIPTION
## Summary

Redesenho radical do **extrato financeiro do app participante** (PWA mobile) — sai o estilo "banco digital" (hero card + glassmorphism + gráfico SVG + timeline cronológica), entra um **cupom de impressora térmica** (papel branco off-white, JetBrains Mono, asteriscos, dashed dividers, código de barras decorativo, saldo final em destaque tipo display).

**Inspiração**: imagem de cupom estilo "Marketing Day 2026" enviada pelo usuário.

**Decisões fechadas com o usuário** (via `AskUserQuestion`):
1. Papel branco fixo (#FAFAF7) — contraste intencional com o app dark
2. Substituição total — sem toggle, sem coexistência com o estilo bank
3. Uma linha por movimentação — espelha extrato bancário, não agrupa

## Mudanças

| Arquivo | Ação | Resumo |
|---|---|---|
| `public/participante/css/extrato-thermal.css` | **NOVO** (458 linhas) | Estrutura BEM, tokens locais `--thermal-*`, responsivo mobile→tablet→desktop, WCAG AAA |
| `public/participante/js/modules/participante-extrato-ui.js` | **REESCRITO** (1711 → 640 linhas) | Adiciona `renderThermalTicket()`, reescreve orquestradores, remove ~1000 linhas de funções órfãs |
| `public/participante/index.html` linha 106 | Edit | `extrato-bank.css?v=20260322` → `extrato-thermal.css?v=20260503` |
| `config/css-registry.json` | Edit | Substitui entry `extrato-bank.css` → `extrato-thermal.css` |

## Anti-Frankenstein

- ✅ Tokens de tipografia reusados de `_app-tokens.css` (`--app-font-mono`, `--app-font-brand`)
- ✅ Keyframe `app-fade-in-up` (já existente) reusado no lugar de duplicata local
- ✅ Animação `app-pulse` (token) substitui keyframe órfão `projecaoPulse` que vivia no `extrato-bank.css`
- ✅ Tokens `--thermal-*` (papel/tinta) escopados em `.thermal-ticket` — proposital, papel branco fixo não adapta ao tema
- ✅ Registrado em `config/css-registry.json`
- ✅ Header JSDoc com Dependência declarada

## Preservado (zero mudança)

- Endpoint `GET /api/fluxo-financeiro/{ligaId}/extrato/{timeId}` — data contract idêntico
- `controllers/fluxoFinanceiroController.js`, `models/ExtratoFinanceiroCache.js`
- `participante-extrato.js` (fetch + cache)
- `fronts/extrato.html` (skeleton de loading genérico continua funcional)
- Export `renderizarProjecaoFinanceira` (consumido por `participante-extrato.js:1657`)
- Helpers de zona/faixa (`getFaixasParaRodada`, `detectarFaixasPorTotal`, etc) — preservados pois alimentam o badge de posição (mito/mico/normal) e podem ser shared

## Edge cases tratados

| Cenário | Comportamento |
|---|---|
| Pré-temporada (`rodadas: []`) | Header + (inscrição) + display "PRÉ-TEMPORADA" + nota mono "Movimentações por rodada aparecerão a partir da rodada 1" + barcode + footer |
| Sem inscrição (`lancamentosIniciais: []`) | Omite seção INSCRIÇÃO e o divider que a segue |
| Sem ajustes / acertos | Omite seção e divider correspondente |
| Rodada com saldo zero | Linha presente com `--zero` (opacidade 0.55), valor `—` |
| Saldo positivo | Status `CRÉDITO` verde escuro (`#0d7a3f`, AA sobre branco) |
| Saldo negativo | Status `DÉBITO` vermelho escuro (`#b91c1c`, AAA Large) |
| Saldo zero | Status `QUITADO` em grafite |
| Valores grandes | Coluna direita `nowrap`, nome trunca com ellipsis |
| Ticket longo (38 rodadas) | Scroll natural + `content-visibility: auto` |

## Test plan

- [ ] Após deploy, abrir extrato como participante de teste em liga ativa (Paulinett — ID 13935277)
- [ ] DevTools → Network: confirmar `extrato-thermal.css?v=20260503` retorna 200 (não 304 cached)
- [ ] Hard reload (Ctrl+Shift+R) para furar cache de service worker
- [ ] Cenário pré-temporada (liga sem rodadas geradas)
- [ ] Cenário temporada em curso (rodadas parciais)
- [ ] Cenário temporada finalizada (38 rodadas + ajustes + acertos) — ticket longo, validar scroll
- [ ] Cenário saldo zero (status QUITADO)
- [ ] Cenário saldo negativo grande (R$ -5.890,50) — DÉBITO vermelho, não quebra coluna
- [ ] Cenário saldo positivo grande — CRÉDITO verde
- [ ] Mobile real (320px iPhone SE / 360px Galaxy) — leaders pontilhados visíveis, valor não quebra
- [ ] Tablet/Desktop — ticket centralizado, max 460px, sombra projetada
- [ ] Screen reader (VoiceOver/TalkBack) — navegação por headings, decorativos ignorados, status lido como texto
- [ ] Card de projeção financeira ao vivo (durante rodada, status_mercado === 2) — animação `app-pulse` funciona, posicionamento acima do ticket OK

## Notas

- **`extrato-bank.css` mantido no disco** para rollback rápido. PR futura (após validação em prod) vai deletar o arquivo + limpar skeleton bank-specific de `fronts/extrato.html`.
- **Verificação visual local não foi possível** neste sandbox (sem `.env`, MongoDB não conecta). Sintaxe JS validada (`node --check`) e JSON validado. Verificação visual real virá com o deploy automático via GitHub Actions na VPS.
- **Não foi rodado lint/typecheck**: o projeto usa Vanilla JS sem TS/ESLint configurado para esse path.

Plano completo: `/root/.claude/plans/root-claude-uploads-4fc29c08-fe28-422e-silly-crane.md`

https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q

---
_Generated by [Claude Code](https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q)_