### PR TITLE
style(extrato-thermal): cabeçalho cupom fiscal clássico

### DIFF
--- a/public/participante/css/extrato-thermal.css
+++ b/public/participante/css/extrato-thermal.css
@@ -92,49 +92,65 @@
     z-index: 2;
 }
 
-/* ===== Header ===== */
+/* ===== Header (cupom fiscal clássico) ===== */
 .thermal-ticket__header {
     text-align: center;
-    margin-bottom: 14px;
+    margin-bottom: 12px;
+    padding: 14px 0 6px;
+    border-top: 3px double var(--thermal-ink);
 }
 
 .thermal-ticket__store {
-    font-size: 9px;
-    letter-spacing: 3px;
-    color: var(--thermal-ink-soft);
+    font-size: 11px;
+    letter-spacing: 2.5px;
+    color: var(--thermal-ink);
     text-transform: uppercase;
-    margin: 0 0 14px;
-    font-weight: 500;
+    margin: 0 0 12px;
+    font-weight: 700;
 }
 
 .thermal-ticket__title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
     font-family: var(--app-font-mono);
-    font-size: 16px;
-    line-height: 1.35;
+    font-size: 18px;
+    line-height: 1.3;
     color: var(--thermal-ink);
-    margin: 0 0 6px;
-    letter-spacing: 4px;
+    margin: 0 0 10px;
+    letter-spacing: 2px;
     text-transform: uppercase;
     font-weight: 700;
 }
 
+.thermal-ticket__title::before,
+.thermal-ticket__title::after {
+    content: "";
+    flex: 0 0 24px;
+    height: 1px;
+    background: var(--thermal-ink);
+}
+
 .thermal-ticket__title span {
-    display: inline;
+    display: inline-block;
+    flex-shrink: 0;
 }
 
 .thermal-ticket__subtitle {
-    font-size: 13px;
+    font-size: 14px;
     color: var(--thermal-ink);
-    font-weight: 700;
-    margin: 10px 0 4px;
-    letter-spacing: 0.5px;
+    font-weight: 800;
+    margin: 8px 0 4px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     word-break: break-word;
 }
 
 .thermal-ticket__meta {
-    font-size: 9px;
+    font-size: 10px;
     color: var(--thermal-ink-soft);
-    margin: 0;
+    margin: 0 0 4px;
     letter-spacing: 0.5px;
 }
 
@@ -147,8 +163,8 @@
 }
 
 .thermal-ticket__divider--asterisks {
-    font-size: 12px;
-    letter-spacing: 4px;
+    font-size: 11px;
+    letter-spacing: 1px;
     color: var(--thermal-ink);
     font-weight: 700;
     margin: 14px 0;

--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -103,7 +103,7 @@
         <link rel="stylesheet" href="css/copa-mundo-2026.css?v=20260409" />
 
         <!-- ✅ Extrato Thermal Ticket (cupom de impressora térmica) -->
-        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260504" />
+        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260505" />
 
         <!-- ✅ Loading Overlay (navegação entre módulos) -->
         <link rel="stylesheet" href="css/pull-refresh.css?v=20260322" />

--- a/public/participante/js/modules/participante-extrato-ui.js
+++ b/public/participante/js/modules/participante-extrato-ui.js
@@ -444,12 +444,12 @@ function renderThermalTicket(extrato, acertos, ligaId, options = {}) {
                     <p class="thermal-ticket__meta">${safeEscapeHtml(ligaNomeRaw)} · ${dataEmissao}</p>
                 </header>
 
-                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">* * * * * * * * * * * * * *</div>
+                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">**********************************</div>
 
                 ${sectionsWithDividers}
                 ${emptyNote}
 
-                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">* * * * * * * * * * * * * *</div>
+                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">**********************************</div>
 
                 <div class="thermal-ticket__display">
                     <p class="thermal-ticket__display-label">${displayLabel}</p>
@@ -615,7 +615,7 @@ function renderizarErro() {
                     <p class="thermal-ticket__store">Super Cartola Manager</p>
                     <h1 class="thermal-ticket__title"><span>Extrato — Erro</span></h1>
                 </header>
-                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">* * * * * * * * * * * * * *</div>
+                <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">**********************************</div>
                 <div class="thermal-ticket__empty">
                     <p style="font-weight:700;margin-bottom:8px">Erro ao carregar extrato</p>
                     <p>Tente novamente em alguns instantes</p>


### PR DESCRIPTION
## Iteração v3 — header cupom fiscal clássico

PR de continuação dos #77 e #78. Resposta ao feedback "olhe o cabeçalho" — header v2 ficou minimalista demais.

### Antes vs. Depois

**Antes (v2)**: header sumindo, sem identidade
**Depois (v3)**: cupom fiscal clássico

```
══════════════════════════════════════
       SUPER CARTOLA MANAGER
       ─── EXTRATO 2026 ───
       URUBU PLAY F.C.
       Liga · 03/05/2026 19:55
**************************************
```

### Mudanças

| Elemento | Antes | Depois |
|---|---|---|
| Border do header | nenhum | `border-top: 3px double ink` |
| Título | mono 16px, letter-spacing 4px (diluído) | mono 18px, letter-spacing 2px, com `::before/::after` lines |
| Store | 9px ink-soft weight 500 | 11px ink weight 700 |
| Subtitle (time) | 13px weight 700 | 14px weight 800 uppercase |
| Meta | 9px | 10px |
| Asteriscos | `* * * * * * *` espaçados (letter-spacing 4px) | `***********` densos (letter-spacing 1px) |
| HTML cache | `?v=20260504` | `?v=20260505` |

### Implementação técnica

- Linhas decorativas ao redor do título via CSS `::before` e `::after` com `flex: 0 0 24px; height: 1px; background: var(--thermal-ink)` — sem caracteres Unicode (evita problemas cross-font), totalmente decorativo
- Título em `display: flex` para alinhar texto entre as linhas
- Asteriscos densos: troca do conteúdo do `<div>` de `* * * * *` para `**********...` (34 caracteres tight)

### Preservado

- Zero mudança em backend, schema, API, lógica financeira
- Breakdown por rodada (v2) intacto
- Premiações & Ajustes cronológicas (v2) intacto

### Test plan

- [ ] Após deploy, hard reload (Ctrl+Shift+R)
- [ ] Faixa `═══` (border duplo) visível no topo do header
- [ ] Título "EXTRATO 2026" emoldurado por linhas horizontais finas
- [ ] Store "SUPER CARTOLA MANAGER" visível e marcado
- [ ] Time name (subtitle) presente em uppercase peso 800
- [ ] Asteriscos aparecem densos (sem espaços)
- [ ] Restante do ticket (rodadas, breakdown, premiações, saldo) inalterado

https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q

---
_Generated by [Claude Code](https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q)_