### PR TITLE
fix(extrato-thermal): nome real do time no header + confirmação multi-tenant

### DIFF
--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -103,7 +103,7 @@
         <link rel="stylesheet" href="css/copa-mundo-2026.css?v=20260409" />
 
         <!-- ✅ Extrato Thermal Ticket (cupom de impressora térmica) -->
-        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260506" />
+        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260507" />
 
         <!-- ✅ Loading Overlay (navegação entre módulos) -->
         <link rel="stylesheet" href="css/pull-refresh.css?v=20260322" />

--- a/public/participante/js/modules/participante-extrato-ui.js
+++ b/public/participante/js/modules/participante-extrato-ui.js
@@ -187,11 +187,16 @@ function renderThermalTicket(extrato, acertos, ligaId, options = {}) {
     const { isPreTemporadaMode = false } = options;
 
     // ===== Identidade do time/liga =====
+    // Cadeia de fallbacks segue paths usados em participante-auth.js, participante-navigation.js
+    // e o source-of-truth no DOM (#nomeTime, atualizado pelo auth ao trocar de liga).
     const timeNome = safeEscapeHtml(
         extrato.time?.nome
+        || extrato.nome_time
         || extrato.timeNome
-        || window.participanteData?.time?.nome
-        || window.participanteData?.timeNome
+        || window.participanteData?.nomeTime
+        || window.participanteData?.participante?.participante?.nome_time
+        || window.participanteAuth?.participante?.participante?.nome_time
+        || document.getElementById('nomeTime')?.textContent?.trim()
         || 'Meu Time'
     );
 


### PR DESCRIPTION
## Bug

O subtitle do ticket renderizava `"Meu Time"` (literal) em vez do nome real do time do participante.

### Causa raiz

Os paths que eu tentava no fallback chain não existem na estrutura de dados real do app participante:

```js
// ANTES — caía sempre no fallback
extrato.time?.nome              // não existe
|| extrato.timeNome             // não existe
|| window.participanteData?.time?.nome   // não existe
|| window.participanteData?.timeNome     // não existe
|| 'Meu Time'                            // ← sempre cai aqui
```

### Fix

Cadeia de fallback corrigida com **paths canônicos usados pelos outros módulos do participante**:

```js
// DEPOIS
extrato.time?.nome
|| extrato.nome_time
|| extrato.timeNome
|| window.participanteData?.nomeTime
|| window.participanteData?.participante?.participante?.nome_time
|| window.participanteAuth?.participante?.participante?.nome_time
|| document.getElementById('nomeTime')?.textContent?.trim()
|| 'Meu Time'
```

Origem dos paths:
- `window.participanteAuth.participante.participante.nome_time` — source-of-truth do auth (atualizado ao logar/trocar liga)
- `window.participanteData.nomeTime` — cache de sessão setado por `participante-navigation.js:109,217,234,252,271`
- `document.getElementById('nomeTime').textContent` — DOM source-of-truth, atualizado por `participante-auth.js:438,520`. **Bullet-proof** — sempre presente quando o app está carregado

## Multi-tenant — confirmação

> "garanta que ambas as ligas as alterações chegaram. até pq nada é hardcode, correto?"

Verificado: **zero hardcoding de `liga_id`** no thermal-ticket. Distribuição é uniforme:

| Componente | Como serve as ligas |
|---|---|
| `extrato-thermal.css` | Carregado por `index.html` para TODOS os participantes, sem condicional |
| `participante-extrato-ui.js` | Mesmo módulo executado igual para todas as ligas |
| Tokens `--thermal-*` | Locais em `.thermal-ticket`, não dependem de liga |
| `ligaId` no JS | Apenas parâmetro de função — não hardcoded |
| Endpoint API | `/api/fluxo-financeiro/{ligaId}/extrato/{timeId}` — mesma rota, dados diferentes por liga |

Único motivo pra um participante ver versão antiga: cache de service worker. **Ctrl+Shift+R** (hard reload) limpa.

## Test plan

- [ ] Após deploy, hard reload pra furar service worker
- [ ] Subtitle do ticket mostra `URUBU PLAY F.C.` (ou nome real, em uppercase) em vez de `MEU TIME`
- [ ] Trocar de liga (se o participante estiver em 2+) → ticket atualiza com nome do time naquela liga
- [ ] Cache busting: confirmar `extrato-thermal.css?v=20260507` no DevTools Network

https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q

---
_Generated by [Claude Code](https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q)_