### PR TITLE
feat(extrato-thermal): projeção ao vivo como mini-ticket destacável

### DIFF
--- a/public/participante/css/extrato-thermal.css
+++ b/public/participante/css/extrato-thermal.css
@@ -514,6 +514,193 @@
     margin: 4px 0;
 }
 
+/* ===== Mini-ticket de projeção ao vivo (stub destacável) =====
+ * Pedaço discreto do mesmo papel, sentado acima do ticket principal.
+ * Borda inferior tracejada simula perfuração "destacar aqui".
+ * Quando rodada não está em curso, fica oculto (controlado pelo JS).
+ */
+.thermal-projection {
+    width: calc(100% - 16px);
+    max-width: 380px;
+    margin: 16px auto 0;
+    padding: 12px 18px 14px;
+    background: var(--thermal-paper);
+    color: var(--thermal-ink);
+    font-family: var(--app-font-mono);
+    font-size: 11px;
+    line-height: 1.5;
+    box-shadow:
+        0 16px 24px -10px rgba(0, 0, 0, 0.55),
+        0 4px 8px -2px rgba(0, 0, 0, 0.35);
+    /* Define tokens locais (mesmos do ticket — papel branco fixo) */
+    --thermal-paper: #FAFAF7;
+    --thermal-ink: #1a1a1a;
+    --thermal-ink-soft: #4a4a4a;
+    --thermal-ink-dim: #9ca3af;
+    --thermal-ink-credit: #0d7a3f;
+    --thermal-ink-debit: #b91c1c;
+    /* Linha tracejada na borda inferior: sugere "destacar aqui" */
+    border-bottom: 1px dashed var(--thermal-ink-soft);
+}
+
+.thermal-projection .thermal-projection__live-indicator {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--thermal-ink);
+    margin: 0 0 6px;
+}
+
+.thermal-projection .thermal-projection__live-dot {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--thermal-ink-credit);
+    animation: app-pulse 2s ease-in-out infinite;
+    flex-shrink: 0;
+}
+
+.thermal-projection .thermal-projection__live-time {
+    margin-left: auto;
+    font-size: 9px;
+    color: var(--thermal-ink-soft);
+    letter-spacing: 0.5px;
+    font-weight: 500;
+}
+
+.thermal-projection .thermal-projection__time {
+    font-size: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--thermal-ink);
+    margin: 0 0 6px;
+    word-break: break-word;
+}
+
+.thermal-projection .thermal-projection__pos-badge {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 0 5px;
+    border: 1px solid var(--thermal-ink-soft);
+    border-radius: 2px;
+    font-size: 9px;
+    font-weight: 700;
+    color: var(--thermal-ink-soft);
+    letter-spacing: 0.5px;
+    vertical-align: middle;
+}
+
+.thermal-projection .thermal-projection__divider {
+    border-top: 1px dashed var(--thermal-ink-soft);
+    margin: 8px 0 6px;
+}
+
+.thermal-projection .thermal-projection__row {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    margin: 3px 0;
+    font-size: 11px;
+    line-height: 1.5;
+}
+
+.thermal-projection .thermal-projection__row-label {
+    color: var(--thermal-ink);
+    font-weight: 700;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.thermal-projection .thermal-projection__row-leader {
+    flex: 1;
+    min-width: 10px;
+    height: 1em;
+    background-image: radial-gradient(circle, var(--thermal-ink-soft) 0.5px, transparent 1.2px);
+    background-size: 5px 5px;
+    background-repeat: repeat-x;
+    background-position: center 70%;
+    align-self: flex-end;
+    margin: 0 4px;
+}
+
+.thermal-projection .thermal-projection__row-value {
+    flex-shrink: 0;
+    white-space: nowrap;
+    font-weight: 700;
+    color: var(--thermal-ink);
+    font-feature-settings: "tnum";
+    font-variant-numeric: tabular-nums;
+}
+
+.thermal-projection .thermal-projection__row-value[data-sign="+"] { color: var(--thermal-ink-credit); }
+.thermal-projection .thermal-projection__row-value[data-sign="-"] { color: var(--thermal-ink-debit); }
+.thermal-projection .thermal-projection__row-value[data-sign="0"] { color: var(--thermal-ink-dim); }
+
+.thermal-projection .thermal-projection__breakdown {
+    list-style: none;
+    margin: 2px 0 4px 12px;
+    padding: 0;
+}
+
+.thermal-projection .thermal-projection__breakdown-item {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    margin: 1px 0;
+    font-size: 10px;
+    line-height: 1.45;
+    color: var(--thermal-ink-soft);
+}
+
+.thermal-projection .thermal-projection__breakdown-label {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+}
+
+.thermal-projection .thermal-projection__breakdown-leader {
+    flex: 1;
+    min-width: 8px;
+    height: 1em;
+    background-image: radial-gradient(circle, var(--thermal-ink-dim) 0.5px, transparent 1.2px);
+    background-size: 4px 4px;
+    background-repeat: repeat-x;
+    background-position: center 70%;
+    align-self: flex-end;
+    margin: 0 4px;
+}
+
+.thermal-projection .thermal-projection__breakdown-value {
+    flex-shrink: 0;
+    white-space: nowrap;
+    font-weight: 600;
+    font-feature-settings: "tnum";
+    font-variant-numeric: tabular-nums;
+}
+
+.thermal-projection .thermal-projection__breakdown-value[data-sign="+"] { color: var(--thermal-ink-credit); }
+.thermal-projection .thermal-projection__breakdown-value[data-sign="-"] { color: var(--thermal-ink-debit); }
+
+/* Quando o card de projeção existe, gruda no ticket abaixo (sem gap) */
+.thermal-projection + .thermal-stage {
+    padding-top: 0;
+}
+.thermal-projection + .thermal-stage .thermal-ticket {
+    margin-top: 0;
+}
+
 /* ===== Tablet ===== */
 @media (min-width: 768px) {
     .thermal-ticket {
@@ -524,6 +711,8 @@
 
     .thermal-ticket__row { font-size: 13px; }
     .thermal-ticket__display { padding: 22px 16px; }
+
+    .thermal-projection { max-width: 420px; }
 }
 
 /* ===== Desktop ===== */
@@ -537,6 +726,14 @@
         margin: 32px auto;
         transform: rotate(-0.4deg);
         transition: transform 0.3s ease;
+    }
+
+    .thermal-projection {
+        max-width: 460px;
+        margin-top: 32px;
+    }
+    .thermal-projection + .thermal-stage .thermal-ticket {
+        margin-top: 0;
     }
 
     .thermal-ticket:hover {

--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -103,7 +103,7 @@
         <link rel="stylesheet" href="css/copa-mundo-2026.css?v=20260409" />
 
         <!-- ✅ Extrato Thermal Ticket (cupom de impressora térmica) -->
-        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260507" />
+        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260508" />
 
         <!-- ✅ Loading Overlay (navegação entre módulos) -->
         <link rel="stylesheet" href="css/pull-refresh.css?v=20260322" />

--- a/public/participante/js/modules/participante-extrato-ui.js
+++ b/public/participante/js/modules/participante-extrato-ui.js
@@ -638,10 +638,13 @@ function renderizarErro() {
 }
 
 // =====================================================================
-// PROJEÇÃO FINANCEIRA EM TEMPO REAL
+// PROJEÇÃO FINANCEIRA EM TEMPO REAL — mini-ticket destacável
+// =====================================================================
 // Card exibido durante rodada em andamento (status_mercado === 2).
 // Importado por participante-extrato.js — manter assinatura.
-// Insere card como overlay informacional ABOVE do ticket no container principal.
+// Estilo: pedaço discreto do mesmo papel térmico, sentado acima do
+// ticket principal, com perfuração tracejada na borda inferior.
+// Mostra apenas o IMPACTO da rodada em curso (não saldo total da temporada).
 // =====================================================================
 
 export function renderizarProjecaoFinanceira(projecaoData) {
@@ -654,50 +657,73 @@ export function renderizarProjecaoFinanceira(projecaoData) {
         if (!mainContainer) return;
         card = document.createElement("div");
         card.id = "projecaoFinanceiraCard";
-        // Inserir antes do ticket térmico
+        card.className = "thermal-projection";
         mainContainer.insertBefore(card, mainContainer.firstChild);
+    } else {
+        // Garantir classe correta caso já exista (re-render)
+        card.className = "thermal-projection";
     }
 
-    const { rodada, time, financeiro, saldo, atualizado_em } = projecaoData;
+    const { rodada, time, financeiro, atualizado_em } = projecaoData;
     const horaAtualizada = atualizado_em
         ? new Date(atualizado_em).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
         : '--:--';
 
-    const saldoProjetado = saldo?.projetado || 0;
-    const saldoCor = saldoProjetado >= 0 ? 'var(--app-success-light, #22c55e)' : 'var(--app-danger-light, #f87171)';
-    const sinal = saldoProjetado > 0 ? '+' : saldoProjetado < 0 ? '−' : '';
-    const valorAbs = Math.abs(saldoProjetado).toFixed(2).replace('.', ',');
+    // Impacto da rodada em curso (delta — NÃO saldo total da temporada)
+    const impacto = financeiro?.impactoProjetado || 0;
+    const sinalImp = signKey(impacto);
+    const valorImpacto = impacto === 0
+        ? formatarMoeda(0)
+        : `${impacto > 0 ? '+ ' : '− '}${formatarMoeda(impacto)}`;
+
+    // Breakdown — só componentes ≠ 0 (mesma lógica das rodadas finalizadas)
+    const breakdown = [];
+    const banco = financeiro?.banco?.valor || 0;
+    const pc = financeiro?.pontosCorridos?.valor || 0;
+    const mm = financeiro?.mataMata?.valor || 0;
+    const top10 = financeiro?.top10?.valor || 0;
+    if (banco !== 0) breakdown.push({ label: banco > 0 ? 'BONUS POSICAO' : 'ONUS POSICAO', valor: banco });
+    if (pc !== 0) breakdown.push({ label: 'PONTOS CORRIDOS', valor: pc });
+    if (mm !== 0) breakdown.push({ label: 'MATA-MATA', valor: mm });
+    if (top10 !== 0) breakdown.push({ label: top10 > 0 ? 'TOP10 MITO' : 'TOP10 MICO', valor: top10 });
+
+    const breakdownHtml = breakdown.length > 1 ? `
+        <ul class="thermal-projection__breakdown" role="list">
+            ${breakdown.map(b => {
+                const bSign = signKey(b.valor);
+                const bValor = `${b.valor > 0 ? '+' : '−'}${formatarMoeda(b.valor).replace('R$ ', '')}`;
+                return `
+                    <li class="thermal-projection__breakdown-item">
+                        <span class="thermal-projection__breakdown-label">${safeEscapeHtml(b.label)}</span>
+                        <span class="thermal-projection__breakdown-leader" aria-hidden="true"></span>
+                        <span class="thermal-projection__breakdown-value" data-sign="${bSign}">${bValor}</span>
+                    </li>
+                `;
+            }).join('')}
+        </ul>
+    ` : '';
+
     const posParcial = time?.posicao_parcial || '-';
-    const nomeTime = time?.nome_time || 'Meu Time';
+    const nomeTime = safeEscapeHtml(
+        time?.nome_time
+        || window.participanteData?.nomeTime
+        || document.getElementById('nomeTime')?.textContent?.trim()
+        || 'Meu Time'
+    );
 
     card.innerHTML = `
-        <div style="
-            margin: 16px 12px 0;
-            padding: 14px 16px;
-            background: linear-gradient(135deg, rgba(34, 197, 94, 0.08) 0%, rgba(34, 197, 94, 0.03) 100%);
-            border: 1.5px dashed rgba(34, 197, 94, 0.4);
-            border-radius: 12px;
-            color: var(--app-text-primary, #e5e5e5);
-            font-family: 'Inter', sans-serif;
-        ">
-            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px">
-                <div style="display:flex;align-items:center;gap:8px">
-                    <span style="display:inline-block;width:8px;height:8px;background:#22c55e;border-radius:50%;animation:app-pulse 2s ease-in-out infinite"></span>
-                    <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;color:#22c55e">
-                        Projeção R${rodada} ao vivo
-                    </span>
-                </div>
-                <span style="font-size:10px;color:var(--app-text-dim,#9ca3af)">${horaAtualizada}</span>
-            </div>
-            <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
-                <div>
-                    <div style="font-size:13px;font-weight:600">${safeEscapeHtml(nomeTime)}</div>
-                    <div style="font-size:10px;color:var(--app-text-dim,#9ca3af);margin-top:2px">Posição parcial: ${posParcial}º</div>
-                </div>
-                <div style="font-family:'JetBrains Mono',monospace;font-size:18px;font-weight:800;color:${saldoCor}">
-                    ${sinal} R$ ${valorAbs}
-                </div>
-            </div>
+        <div class="thermal-projection__live-indicator">
+            <span class="thermal-projection__live-dot" aria-hidden="true"></span>
+            <span>Projeção R${rodada} ao vivo</span>
+            <span class="thermal-projection__live-time">${horaAtualizada}</span>
         </div>
+        <p class="thermal-projection__time">${nomeTime}<span class="thermal-projection__pos-badge">${posParcial}º</span></p>
+        <div class="thermal-projection__divider" aria-hidden="true"></div>
+        <div class="thermal-projection__row">
+            <span class="thermal-projection__row-label">Impacto R${rodada}</span>
+            <span class="thermal-projection__row-leader" aria-hidden="true"></span>
+            <span class="thermal-projection__row-value" data-sign="${sinalImp}">${valorImpacto}</span>
+        </div>
+        ${breakdownHtml}
     `;
 }


### PR DESCRIPTION
## Mudança

Resposta ao feedback "em 'Projeção ao Vivo' o que é aquele valor?". O valor exibido (`saldo.projetado`) era ambíguo — sem label, parecia impacto da rodada mas era saldo total da temporada projetado.

### Antes

```
● PROJEÇÃO R14 AO VIVO        20:02
Urubu Play F.C.
Posição parcial: 34º            -R$ 147,00   ← saldo TOTAL temporada (sem label)
```

### Depois

```
● PROJEÇÃO R14 AO VIVO          20:02
URUBU PLAY F.C.   [34º]
- - - - - - - - - - - - - - -
IMPACTO R14 ............... -R$ 18,00
  ÔNUS POSICAO ................ -13,00
  PONTOS CORRIDOS .............. -5,00
- - - - - - - - - - - - - - -   ← perfuração ("destacar aqui")
══════════════════════════════════════
       SUPER CARTOLA MANAGER
       ─── EXTRATO 2026 ───
       URUBU PLAY F.C.
       ...
```

Mostra **só o impacto da rodada em curso** (delta), com breakdown dos componentes. Visualmente: pedaço discreto do mesmo papel térmico, perfurado, sentado acima do ticket principal.

## Implementação

### CSS — `.thermal-projection*` (~180 linhas novas)
- Mesma paleta local do ticket (`--thermal-paper`, `--thermal-ink`, etc.)
- Sombra projetada igual, mas grudado no ticket abaixo (margin-bottom: 0)
- `border-bottom: 1px dashed` simula perfuração "destacar aqui"
- Selectors prefixados com `.thermal-projection` pra vencer especificidade de `.module-container p/h1` (lição do PR #80)
- Responsivo: 380→420→460px (mesmos breakpoints do ticket)
- `app-pulse` (token de `_app-tokens.css`) anima o dot indicador "ao vivo"

### JS — `renderizarProjecaoFinanceira` reescrita
- Trocado `saldo.projetado` → `financeiro.impactoProjetado` (delta da rodada)
- Breakdown opcional: `banco.valor`, `pontosCorridos.valor`, `mataMata.valor`, `top10.valor` (só componentes ≠ 0, threshold > 1 igual às rodadas finalizadas)
- Estrutura: indicador "ao vivo" pulsante + nome time + posição parcial + linha "IMPACTO RXX" + breakdown indentado
- Nome do time com fallback chain unificado (mesmo do header do ticket)
- Removido estilo glass dark/Inter, agora 100% mono/papel/cupom

## Multi-tenant

Zero hardcoding de `liga_id`. Mini-ticket renderiza com dados da API existente (`projecaoData` vindo do endpoint de projeção), aplica-se uniformemente a todas as ligas.

## Test plan

- [ ] Após deploy, hard reload pra furar service worker
- [ ] Card "Projeção R14 ao vivo" aparece **apenas durante rodada em curso** (status_mercado === 2)
- [ ] Visual: papel branco, mono, asteriscos densos no header, perfuração tracejada no rodapé
- [ ] Mini-ticket "encosta" no ticket principal abaixo (sem gap visível)
- [ ] Linha "IMPACTO R14" mostra delta da rodada (não saldo da temporada)
- [ ] Breakdown aparece se 2+ componentes (BONUS POSICAO + PONTOS CORRIDOS, etc.)
- [ ] Componentes únicos não mostram breakdown (limpo)
- [ ] Dot verde pulsando ao lado de "Projeção R14 ao vivo"
- [ ] Hora atualizada no canto direito do indicador
- [ ] Responsive: largura aumenta no tablet/desktop, mantém alinhamento com ticket

https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q

---
_Generated by [Claude Code](https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q)_