### PR TITLE
feat(extrato-thermal): expor status de inscrição mesmo dispensada/gratuita/quitada

### DIFF
--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -103,7 +103,7 @@
         <link rel="stylesheet" href="css/copa-mundo-2026.css?v=20260409" />
 
         <!-- ✅ Extrato Thermal Ticket (cupom de impressora térmica) -->
-        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260508" />
+        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260509" />
 
         <!-- ✅ Loading Overlay (navegação entre módulos) -->
         <link rel="stylesheet" href="css/pull-refresh.css?v=20260322" />

--- a/public/participante/js/modules/participante-extrato-ui.js
+++ b/public/participante/js/modules/participante-extrato-ui.js
@@ -136,6 +136,9 @@ function safeEscapeHtml(str) {
 function getNomeLancamento(l, temporada) {
     if (l.tipo === 'INSCRICAO_TEMPORADA') return `INSCRIÇÃO ${temporada}`;
     if (l.tipo === 'TRANSFERENCIA_SALDO' || l.tipo === 'SALDO_TEMPORADA_ANTERIOR') return 'SALDO ANTERIOR';
+    if (l.tipo === 'INSCRICAO_GRATUITA') return `INSCRIÇÃO ${temporada} — LIGA SEM TAXA`;
+    if (l.tipo === 'INSCRICAO_QUITADA') return `INSCRIÇÃO ${temporada} QUITADA`;
+    if (l.tipo === 'INSCRICAO_DISPENSADA') return `INSCRIÇÃO ${temporada} DISPENSADA`;
     return safeEscapeHtml((l.descricao || l.tipo || 'LANÇAMENTO')).toUpperCase();
 }
 
@@ -232,9 +235,37 @@ function renderThermalTicket(extrato, acertos, ligaId, options = {}) {
     const sections = [];
 
     // --- Inscrição ---
-    if (entradas.length > 0) {
-        const total = entradas.reduce((s, l) => s + (l.valor || 0), 0);
-        const rowsHtml = entradas.map(l => renderRow({
+    // Quando NÃO existe lancamento INSCRICAO_TEMPORADA, sintetizar entrada
+    // de status para expor a situação ao participante (em vez de simplesmente
+    // omitir a seção). Categorização baseada nos campos resumo.taxaInscricao
+    // e resumo.pagouInscricao que vêm do backend (extratoFinanceiroCacheController).
+    const taxaInscConfig = extrato.resumo?.taxaInscricao || extrato.resumo?.taxa_inscricao || 0;
+    const pagouInscConfig = extrato.resumo?.pagouInscricao === true
+        || extrato.resumo?.pagou_inscricao === true;
+    const hasInscLancamento = entradas.some(l => l.tipo === 'INSCRICAO_TEMPORADA');
+
+    let entradasComStatus = [...entradas];
+    if (!hasInscLancamento && !isPreTemporadaMode) {
+        // Sem débito de inscrição em modo regular — sintetizar linha explicativa
+        let tipoSintetico;
+        if (taxaInscConfig === 0) {
+            tipoSintetico = 'INSCRICAO_GRATUITA';
+        } else if (pagouInscConfig) {
+            tipoSintetico = 'INSCRICAO_QUITADA';
+        } else {
+            // taxa > 0 mas sem lancamento e sem flag pago → owner/premium isento
+            tipoSintetico = 'INSCRICAO_DISPENSADA';
+        }
+        entradasComStatus.unshift({
+            tipo: tipoSintetico,
+            valor: 0,
+            _sintetico: true,
+        });
+    }
+
+    if (entradasComStatus.length > 0) {
+        const total = entradasComStatus.reduce((s, l) => s + (l.valor || 0), 0);
+        const rowsHtml = entradasComStatus.map(l => renderRow({
             name: getNomeLancamento(l, temporada),
             valor: l.valor || 0,
             allowHtmlInName: true


### PR DESCRIPTION
## Mudança

Resposta ao feedback do usuário: o extrato hoje OMITE a seção INSCRIÇÃO quando o backend não cria o lancamento `INSCRICAO_TEMPORADA` — caso típico de owner/premium isento ou liga sem taxa. O participante fica sem confirmação visual da sua situação.

### Antes
```
══════════════════════════════════════
   SUPER CARTOLA MANAGER
   ─── EXTRATO 2026 ───
   PAULINETT — URUBU PLAY F.C.
**********************************

RODADAS — TEMPORADA 2026                ← seção INSCRIÇÃO ausente
  RODADA 01 [34º] ............ -R$ 14,00
  ...
```

### Depois (Liga Super Cartola — Paulinett dispensado)
```
══════════════════════════════════════
   SUPER CARTOLA MANAGER
   ─── EXTRATO 2026 ───
**********************************

INSCRIÇÃO
  INSCRIÇÃO 2026 DISPENSADA ........ R$ 0,00
  Subtotal ........................... R$ 0,00
- - - - - - - - - - - - - - - - - - -
RODADAS — TEMPORADA 2026
  ...
```

### Depois (Liga Os Fuleiros — Paulinett deve R$ 100)
Sem mudança — segue mostrando o débito real:
```
INSCRIÇÃO
  INSCRIÇÃO 2026 ................. -R$ 100,00
  Subtotal ......................... -R$ 100,00
```

## Lógica de detecção

Em `renderThermalTicket`, antes de renderizar a seção INSCRIÇÃO:

```js
const taxaInsc = extrato.resumo?.taxaInscricao || 0;
const pagouInsc = extrato.resumo?.pagouInscricao === true;
const hasInscLancamento = entradas.some(l => l.tipo === 'INSCRICAO_TEMPORADA');

if (!hasInscLancamento && !isPreTemporadaMode) {
    if (taxaInsc === 0)        sintetizar('INSCRICAO_GRATUITA');
    else if (pagouInsc)        sintetizar('INSCRICAO_QUITADA');
    else                       sintetizar('INSCRICAO_DISPENSADA');
}
```

| Cenário | Detecção | Label sintético |
|---|---|---|
| Liga gratuita (taxa = 0) | `taxaInsc === 0` | `INSCRIÇÃO 2026 — LIGA SEM TAXA` |
| Pago anteriormente | `pagouInsc === true` (raro/legacy) | `INSCRIÇÃO 2026 QUITADA` |
| Owner/premium isento | `taxaInsc > 0` + sem lancamento + não pago | `INSCRIÇÃO 2026 DISPENSADA` |

Pré-temporada não usa esse caminho — preserva a lógica própria de `renderizarConteudoRenovadoPreTemporada`.

## Multi-tenant

Heurística usa só campos já universais (`resumo.taxaInscricao`, `resumo.pagouInscricao`). Zero hardcoding de `liga_id`. Aplica-se a todas as ligas.

## Limitação conhecida

Não existe flag explícito `isOwnerPremium` no payload do backend. O front infere via combinação. Cenários edge (ex: liga gratuita pra TODOS + participante owner) caem em `GRATUITA` o que está semanticamente correto. Se quiser distinção 100% precisa entre "DISPENSADA pelo admin" vs "GRATUITA pra liga toda", basta adicionar `resumo.isOwnerPremium: boolean` no `extratoFinanceiroCacheController` (linha ~947 onde já busca `inscDoc.pagou_inscricao`).

## Test plan

- [ ] Após deploy, hard reload pra furar service worker
- [ ] **Liga Super Cartola** (Paulinett dispensado): seção INSCRIÇÃO aparece com `INSCRIÇÃO 2026 DISPENSADA ... R$ 0,00`
- [ ] **Liga Os Fuleiros** (Paulinett deve R$ 100): seção INSCRIÇÃO aparece com `-R$ 100,00` (sem mudança)
- [ ] Liga com taxa=0 explícita: aparece `LIGA SEM TAXA`
- [ ] Pré-temporada de uma liga ativa: comportamento atual mantido (sem sinteise extra)

https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q

---
_Generated by [Claude Code](https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q)_