### PR TITLE
feat(extrato-thermal): botão discreto de refresh no canto superior direito

### DIFF
--- a/public/participante/css/extrato-thermal.css
+++ b/public/participante/css/extrato-thermal.css
@@ -92,6 +92,46 @@
     z-index: 2;
 }
 
+/* ===== Botão "atualizar" discreto no canto superior direito =====
+ * Single character ↻ em mono. Discreto — não compete com header.
+ * Onclick chama window.forcarRefreshExtratoParticipante() que invalida
+ * cache local + bate no backend com ?refresh=true.
+ */
+.thermal-ticket .thermal-ticket__refresh {
+    position: absolute;
+    top: 12px;
+    right: 14px;
+    background: transparent;
+    border: 1px solid var(--thermal-ink-soft);
+    border-radius: 50%;
+    width: 26px;
+    height: 26px;
+    color: var(--thermal-ink-soft);
+    font-family: var(--app-font-mono);
+    font-size: 14px;
+    font-weight: 700;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    z-index: 3;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.thermal-ticket .thermal-ticket__refresh:hover,
+.thermal-ticket .thermal-ticket__refresh:focus-visible {
+    color: var(--thermal-ink);
+    border-color: var(--thermal-ink);
+    outline: none;
+}
+
+.thermal-ticket .thermal-ticket__refresh:active {
+    transform: rotate(180deg);
+}
+
 /* ===== Header (cupom fiscal clássico) =====
  * IMPORTANTE: seletores prefixados com .thermal-ticket para ganhar
  * especificidade sobre .module-container h1/h2/p que vem do

--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -103,7 +103,7 @@
         <link rel="stylesheet" href="css/copa-mundo-2026.css?v=20260409" />
 
         <!-- ✅ Extrato Thermal Ticket (cupom de impressora térmica) -->
-        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260509" />
+        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260510" />
 
         <!-- ✅ Loading Overlay (navegação entre módulos) -->
         <link rel="stylesheet" href="css/pull-refresh.css?v=20260322" />

--- a/public/participante/js/modules/participante-extrato-ui.js
+++ b/public/participante/js/modules/participante-extrato-ui.js
@@ -472,6 +472,11 @@ function renderThermalTicket(extrato, acertos, ligaId, options = {}) {
             <article class="thermal-ticket" role="region" aria-label="Extrato financeiro de ${timeNome}">
                 <span class="thermal-ticket__edge thermal-ticket__edge--top" aria-hidden="true"></span>
                 <span class="thermal-ticket__pin" aria-hidden="true"></span>
+                <button class="thermal-ticket__refresh"
+                        type="button"
+                        onclick="window.forcarRefreshExtratoParticipante && window.forcarRefreshExtratoParticipante()"
+                        aria-label="Atualizar extrato"
+                        title="Atualizar extrato">↻</button>
 
                 <header class="thermal-ticket__header">
                     <p class="thermal-ticket__store">Super Cartola Manager</p>


### PR DESCRIPTION
## Mudança

Resposta ao caso "Liga Os Fuleros não atualizou": cache IndexedDB do PWA (`ParticipanteCache`) tem TTL de **30 dias** para rodadas fechadas e o `Ctrl+Shift+R` não toca o IndexedDB. Sem mecanismo no ticket pra forçar atualização, o participante fica preso em dados defasados.

## Solução

Botão discreto de refresh no canto superior direito do ticket — círculo 26x26px com `↻` em mono, color `ink-soft` por padrão e `ink` no hover. Onclick chama `window.forcarRefreshExtratoParticipante()` que já existia (limpa cache local + bate `?refresh=true` no backend + recalcula + re-renderiza).

## Visual

```
══════════════════════════════════════ ⊙       ← botão refresh
       SUPER CARTOLA MANAGER
       ─── EXTRATO 2026 ───
       URUBU PLAY F.C.
       Liga · 04/05/2026 19:55
**********************************
```

`:active` rotaciona 180° pra dar feedback "rodando".

## Implementação

- **JS** (`renderThermalTicket`): inclui `<button class="thermal-ticket__refresh">` logo após o pin, com z-index 3 (sobre edge zigzag), `aria-label="Atualizar extrato"`, e onclick safe-guard `window.forcarRefreshExtratoParticipante && ...`
- **CSS** (`extrato-thermal.css`): novo bloco `.thermal-ticket .thermal-ticket__refresh` — selectors com scope `.thermal-ticket` pra vencer especificidade de `.module-container button` (lição das iterações anteriores)
- **HTML** (`index.html`): bump `?v=20260509` → `?v=20260510`

## Multi-tenant

Zero hardcoding de `liga_id`. Botão aparece em qualquer liga, qualquer participante. Não toca em backend.

## Test plan

- [ ] Após deploy, hard reload pra furar service worker
- [ ] Botão `↻` visível no canto superior direito do ticket, discreto e em escala com header
- [ ] Click no botão → loading state aparece no container ("Recalculando extrato...") → ticket re-renderiza com dados frescos
- [ ] Liga Os Fuleros: clicar refresh → INSCRIÇÃO 2026 (-R$ 100,00) aparece corretamente
- [ ] Liga Super Cartola: clicar refresh → mantém INSCRIÇÃO 2026 DISPENSADA
- [ ] Mobile: botão clicável sem highlight feio (`-webkit-tap-highlight-color: transparent`)
- [ ] Acessibilidade: `aria-label` lido por screen reader, focus-visible mostra borda

https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q

---
_Generated by [Claude Code](https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q)_