### PR TITLE
refactor(extrato-thermal): liga name no header + remove botão refresh redundante

### DIFF
--- a/public/participante/css/extrato-thermal.css
+++ b/public/participante/css/extrato-thermal.css
@@ -92,46 +92,6 @@
     z-index: 2;
 }
 
-/* ===== Botão "atualizar" discreto no canto superior direito =====
- * Single character ↻ em mono. Discreto — não compete com header.
- * Onclick chama window.forcarRefreshExtratoParticipante() que invalida
- * cache local + bate no backend com ?refresh=true.
- */
-.thermal-ticket .thermal-ticket__refresh {
-    position: absolute;
-    top: 12px;
-    right: 14px;
-    background: transparent;
-    border: 1px solid var(--thermal-ink-soft);
-    border-radius: 50%;
-    width: 26px;
-    height: 26px;
-    color: var(--thermal-ink-soft);
-    font-family: var(--app-font-mono);
-    font-size: 14px;
-    font-weight: 700;
-    cursor: pointer;
-    padding: 0;
-    line-height: 1;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transition: color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
-    z-index: 3;
-    -webkit-tap-highlight-color: transparent;
-}
-
-.thermal-ticket .thermal-ticket__refresh:hover,
-.thermal-ticket .thermal-ticket__refresh:focus-visible {
-    color: var(--thermal-ink);
-    border-color: var(--thermal-ink);
-    outline: none;
-}
-
-.thermal-ticket .thermal-ticket__refresh:active {
-    transform: rotate(180deg);
-}
-
 /* ===== Header (cupom fiscal clássico) =====
  * IMPORTANTE: seletores prefixados com .thermal-ticket para ganhar
  * especificidade sobre .module-container h1/h2/p que vem do

--- a/public/participante/index.html
+++ b/public/participante/index.html
@@ -103,7 +103,7 @@
         <link rel="stylesheet" href="css/copa-mundo-2026.css?v=20260409" />
 
         <!-- ✅ Extrato Thermal Ticket (cupom de impressora térmica) -->
-        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260510" />
+        <link rel="stylesheet" href="css/extrato-thermal.css?v=20260511" />
 
         <!-- ✅ Loading Overlay (navegação entre módulos) -->
         <link rel="stylesheet" href="css/pull-refresh.css?v=20260322" />

--- a/public/participante/js/modules/participante-extrato-ui.js
+++ b/public/participante/js/modules/participante-extrato-ui.js
@@ -472,17 +472,12 @@ function renderThermalTicket(extrato, acertos, ligaId, options = {}) {
             <article class="thermal-ticket" role="region" aria-label="Extrato financeiro de ${timeNome}">
                 <span class="thermal-ticket__edge thermal-ticket__edge--top" aria-hidden="true"></span>
                 <span class="thermal-ticket__pin" aria-hidden="true"></span>
-                <button class="thermal-ticket__refresh"
-                        type="button"
-                        onclick="window.forcarRefreshExtratoParticipante && window.forcarRefreshExtratoParticipante()"
-                        aria-label="Atualizar extrato"
-                        title="Atualizar extrato">↻</button>
 
                 <header class="thermal-ticket__header">
-                    <p class="thermal-ticket__store">Super Cartola Manager</p>
+                    <p class="thermal-ticket__store">${safeEscapeHtml(ligaNomeRaw).toUpperCase()}</p>
                     <h1 class="thermal-ticket__title"><span>Extrato ${temporada}</span></h1>
                     <p class="thermal-ticket__subtitle">${timeNome}</p>
-                    <p class="thermal-ticket__meta">${safeEscapeHtml(ligaNomeRaw)} · ${dataEmissao}</p>
+                    <p class="thermal-ticket__meta">${dataEmissao}</p>
                 </header>
 
                 <div class="thermal-ticket__divider thermal-ticket__divider--asterisks" aria-hidden="true">**********************************</div>


### PR DESCRIPTION
## Mudança

Resposta a 2 feedbacks do screenshot da Liga "Os Fuleros":

1. **Liga name no header** — antes: literal `SUPER CARTOLA MANAGER` (genérico, app name). Depois: nome real da liga (`OS FULEROS`, `SUPER CARTOLA`, etc.) — cria identidade do grupo
2. **Remoção do botão refresh redundante** — o `↻` que eu adicionei no PR #84 é duplicado com o botão refresh já existente no header da aplicação. Removido + CSS órfão limpo

### Antes
```
══════════════════════════════════════ ↻
       SUPER CARTOLA MANAGER
       ─── EXTRATO 2026 ───
       URUBU PLAY F.C.
       Liga Os Fuleros · 04/05/2026 19:55
**********************************
```

### Depois
```
══════════════════════════════════════
       OS FULEROS                    ← nome da liga
       ─── EXTRATO 2026 ───
       URUBU PLAY F.C.
       04/05/2026 · 19:55             ← só data
**********************************
```

## Implementação

- **JS** (`renderThermalTicket`): store slot agora usa `${safeEscapeHtml(ligaNomeRaw).toUpperCase()}` em vez de literal. O `ligaNomeRaw` já existia no escopo com fallback chain robusto
- **JS**: meta line simplificada para `${dataEmissao}` apenas — sem repetir liga (subiu pro store)
- **JS**: removido `<button class="thermal-ticket__refresh">` do header do ticket. `window.forcarRefreshExtratoParticipante` continua disponível, chamado pelo botão refresh do header da aplicação
- **CSS**: removido bloco `.thermal-ticket .thermal-ticket__refresh` (38 linhas: base + :hover + :focus-visible + :active)
- **HTML**: bump `?v=20260510` → `?v=20260511`

## Multi-tenant

Liga name vem de `extrato.ligaConfig.nome` — universal, set por liga via API. Zero hardcoding de `liga_id`. Cada liga mostra o próprio nome.

## Test plan

- [ ] Após deploy, hard reload pra furar service worker
- [ ] Liga Os Fuleros: header mostra `OS FULEROS` em vez de `SUPER CARTOLA MANAGER`
- [ ] Liga Super Cartola: header mostra `SUPER CARTOLA` (nome real da liga)
- [ ] Botão `↻` não aparece mais dentro do ticket — só o do header da app
- [ ] Botão refresh do header da app continua funcionando (chama `forcarRefreshExtratoParticipante`)
- [ ] Meta line mostra só data/hora, sem repetir liga

## Diff stats

```
3 files changed, 3 insertions(+), 48 deletions(-)
```

Mais código removido do que adicionado — refactor enxuto.

https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q

---
_Generated by [Claude Code](https://claude.ai/code/session_013TakVGqtdr8EFDS3tJ9V1q)_