### PR TITLE
fix(ranking): excluir rodadas com falha de API do cálculo de ranking

### DIFF
--- a/routes/ligas.js
+++ b/routes/ligas.js
@@ -262,7 +262,8 @@ router.get("/:id/ranking", async (req, res) => {
     const inativos = await getParticipantesInativos(ligaId);
 
     // ✅ v9.0: Filtrar por temporada para nao misturar dados de temporadas diferentes
-    const rodadas = await Rodada.find({ ligaId, temporada: temporadaFiltro }).lean();
+    // ✅ v9.1: Excluir rodadas com falha de API (consistente com endpoint de rodadas)
+    const rodadas = await Rodada.find({ ligaId, temporada: temporadaFiltro, populacaoFalhou: { $ne: true } }).lean();
 
     if (!rodadas || rodadas.length === 0) {
       return res.json([]);


### PR DESCRIPTION
## Contexto
Branch órfã (`claude/fix-score-display-oTeNC`, commit 4f70b271 de 21/04/2026) que **nunca teve PR** — descoberta numa varredura de branches esquecidas. O bug que ela corrige **ainda está vivo em produção** (verificado: `routes/ligas.js` na `main` não filtra `populacaoFalhou`).

## Bug
Rodadas com `populacaoFalhou: true` ficam com `pontos: 0`. No endpoint `/:id/ranking` (`routes/ligas.js`) elas entram no cálculo, **inflando `rodadas_jogadas` e distorcendo a média / última pontuação** exibida na home do participante quando a rodada mais recente falhou na população da API.

## Fix (1 linha)
`routes/ligas.js` (endpoint `/:id/ranking`): adiciona `populacaoFalhou: { $ne: true }` ao `Rodada.find(...)`, tornando-o **consistente** com o endpoint de rodadas, que já filtra (`controllers/rodadaController.js:561`).

## Validação
- ✅ Premissa de consistência confirmada: `rodadaController.js:561` já aplica `populacaoFalhou: { $ne: true }`.
- ✅ Linha-alvo intacta na `main` → aplica limpo.

## Follow-up (fora do escopo deste fix)
Há uma query idêntica em `routes/ligas.js:635` (outro endpoint) que **não** recebe o filtro. Avaliar se também precisa, em PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)